### PR TITLE
Clock scheduler layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Based on [cocotb-stub-sim](https://github.com/fvutils/cocotb-stub-sim).
 **Proof of Concept** – expect limitations (see below).  
 
 - Only top-level ports are accessible (simulator limitation).  
-- Only the `Timer` trigger is supported (simulator limitation).  
+- Edge-triggers `Edge`, `RisingEdge`, `FallingEdge` only work on clocks generated in the testbench/python with cocotb.clock.Clock() driver." (simulator limitation, see below).
 - Setting signal values is immediate (`setimmediatevalue` behavior).  
 - Only **Verilog top-levels** are supported (VHDL support planned).  
 - Direct access to the **XSI interface** is available.  
@@ -66,9 +66,17 @@ Extra feature: One does not need to recompile the project when running/changing 
 
 You can use `XSI` interface directly see `tests/test_xsi.py` for an example.
 
+## Overcoming `XSI` limitations
+
+`XSI` interface natively supports only `Timer` trigger.
+
+To allow for using edge triggers under this limitation, cocotb-vivado  provides its custom trigger mechanism. When `cocotb_vivado` is imported, a global ClockScheduler singleton is created. This scheduler replaces cocotb’s standard implementations of `Clock`, `Edge`, `RisingEdge`, and `FallingEdge`.
+
+The monkey‑patched Clock objects register themselves with the scheduler, which drives the associated signals and observes every resulting transition. On each clock‑driven edge, the scheduler evaluates all pending edge triggers and resumes any coroutines waiting on them. This polling‑on‑edge model gives deterministic behavior for multiple clocks while keeping the standard cocotb coroutine interface unchanged.
+
 ## cocotb extensions
 
-In order to use cocotb extension like [cocotbext-axi](https://github.com/alexforencich/cocotbext-axi)  one needs to mock the triggers (`XSI` limitations) by creating global clock timer and synchronizes all trigger events to it. See `tests/test_axil.py` for an example.
+In order to use cocotb extension like [cocotbext-axi](https://github.com/alexforencich/cocotbext-axi) one needs to use `Clock` driver for clocking their DUT.
 
 ## Full Vivado design simulation
 

--- a/src/cocotb_vivado/__init__.py
+++ b/src/cocotb_vivado/__init__.py
@@ -6,6 +6,16 @@ import os
 sys.modules["cocotb.simulator"] = importlib.import_module("cocotb_vivado.stub.simulator")
 
 import cocotb
+
+# monkey-patch the clock & trigger layer
+import cocotb.clock
+import cocotb.triggers
+from .clock_scheduler import ScheduledClock, RisingEdge, FallingEdge, Edge
+cocotb.clock.Clock = ScheduledClock
+cocotb.triggers.RisingEdge = clock_scheduler.RisingEdge
+cocotb.triggers.FallingEdge = clock_scheduler.FallingEdge
+cocotb.triggers.Edge = clock_scheduler.Edge
+
 from .stub.mgr import Mgr
 
 

--- a/src/cocotb_vivado/clock_scheduler.py
+++ b/src/cocotb_vivado/clock_scheduler.py
@@ -1,0 +1,216 @@
+import logging
+import typing
+from collections import defaultdict
+from decimal import Decimal
+from numbers import Real
+
+import cocotb.clock
+from cocotb import start_soon
+from cocotb.utils import get_sim_steps, get_time_from_sim_steps, get_sim_time
+from cocotb.task import Task
+from cocotb.triggers import Timer, Event
+
+
+class ScheduledClock:
+    """
+    Simple 50:50 duty cycle clock driver.
+
+    Mimicing cocotb v1.9.2 interface, although cycle count mechanism is deprecated in v2.0.0
+    """
+    def __init__(self, signal, period: float|Real|Decimal, units: str = "step"):
+        self.signal = signal
+        self.period = get_sim_steps(period, units)
+        self.frequency = 1 / get_time_from_sim_steps(self.period, units="us")
+        self.start_high = False
+        self.cycles: int | None = None  # run indefinitely
+        self._remaining_cycles = self.cycles
+        self._task: Task | None = None
+        self._start_time = 0
+        self._stop_event = Event()
+
+    async def start(self, cycles: int|None = None, start_high: bool = True):
+        """ Start the clock by adding it to the scheduler's clock collection. """
+        self.cycles = cycles
+        self._remaining_cycles = self.cycles
+        self.start_high = start_high
+
+        # record the start time for phase offset, and drive signal initial state
+        self._start_time = get_sim_time()
+        self._drive_signal(False)
+
+        _scheduler.add_clock(self)
+        await self._stop_event.wait()  # wait for clock stop event
+        self.stop()
+
+    def stop(self):
+        _scheduler.remove_clock(self)
+
+    def _drive_signal(self, new_value: bool):
+        """ Set clock signal state """
+        if self._remaining_cycles is not None:
+            current_value = self.signal.value
+            if current_value.is_resolvable:
+                if current_value  ^ self.start_high and not new_value:
+                    # falling edge, reduce the cycle count
+                    self._remaining_cycles -= 1
+                if self._remaining_cycles <= 0:
+                    # clock finished
+                    self._stop_event.set()
+
+        # drive the signal taking phase inversion into account
+        self.signal.setimmediatevalue(new_value ^ self.start_high)
+
+
+class ClockScheduler:
+    """
+    ClockSheduler singleton instantiated at module import.
+
+    Keeps track of test cases' Clock objects, and implements polling mechanism to implement
+    alternative trigger events at every input clock edge.
+    """
+    def __init__(self):
+        self.clocks: list[ScheduledClock] = []
+        self.poll_event = Event()
+        self.current_time = 0
+        self.log = logging.getLogger(self.__module__)
+        self.log.setLevel(logging.INFO)
+        self._scheduler_task: Task | None = None
+
+    def reset(self):
+        self.clocks = []
+        self._scheduler_task = None
+
+    def add_clock(self, new_clock: ScheduledClock):
+        if self._scheduler_task is not None and self._scheduler_task.done():
+            # detect if scheduler task was started but cancelled -> reset sceduler to start fresh
+            # this is expected when:
+            # 1. previous cocotb.test() or module finishes
+            # 2. last running ScheduledClock is stopped
+            self.reset()
+
+        for clk in self.clocks:
+            if new_clock.signal == clk.signal:
+                raise RuntimeError(f"signal {clk.signal._name} already assigned a clock driver")
+
+        # add the clock to scheduler
+        self.clocks.append(new_clock)
+
+        # start the sceduler task if not already running
+        if self._scheduler_task is None:
+            self._scheduler_task = start_soon(self.run())
+
+        # Log clock configuration
+        self.log.info("Driving Clock signal: '%s', Frequency: %.3f MHz", new_clock.signal._name, new_clock.frequency)
+
+    def remove_clock(self, clock: ScheduledClock):
+        self.clocks.remove(clock)
+        if not self.clocks:
+            # last clock removed, stop the scheduler
+            self._scheduler_task.cancel()
+
+    def _get_clock_transitions(self, current_time):
+        """
+        Calculate next clock transitions for registered clocks.
+
+        Clock cycle is defined as 50% low - 50% high polarity
+        """
+        # Advance beyond the current timestep to capture the _next_ transition, hence +1
+        current_time += 1
+
+        clk_transitions = []
+        for clk in self.clocks:
+            half_period = clk.period / 2.0  # assume 50% duty cycle
+
+            # Find the position in the cycle.
+            cycle_pos = (current_time - clk._start_time) % clk.period
+
+            if cycle_pos < half_period:
+                # Currently low, next transition is rising edge
+                transition_time = current_time + (half_period - cycle_pos)
+                transition_to = 1
+            else:
+                # Currently high, next transition is falling edge
+                transition_time = current_time + (clk.period - cycle_pos)
+                transition_to = 0
+
+            clk_transitions.append((transition_time, (clk, transition_to)))
+
+        # Find earliest time and collect all transitions at that time
+        next_transition_time = min(t for t, _ in clk_transitions)
+        next_transitions = [item for t, item in clk_transitions if t == next_transition_time]
+
+        return next_transition_time, next_transitions
+
+    async def run(self):
+        """ ClockScheduler main coroutine. """
+        self.log.info("ClockScheduler started")
+        while self.clocks:
+            sim_time = get_sim_time()
+            next_transition_time, next_clock_transition_ops = self._get_clock_transitions(sim_time)
+
+            wait_time = next_transition_time - sim_time
+            await Timer(wait_time, units="step")
+
+            # drive scheduled clk transitions
+            for clk, value in next_clock_transition_ops:
+                clk._drive_signal(value)
+
+            # trigger update event on every scheduled clock edge
+            self.poll_event.set()
+            self.poll_event.clear()
+
+
+# Instantiate scheduler singleton at import
+_scheduler = ClockScheduler()
+
+
+# Overloaded transition triggers using ClockScheduler's poll event
+class FallingEdge:
+    def __init__(self, signal):
+        self.signal = signal
+
+    def __await__(self):
+        return self._async_method().__await__()
+
+    async def _async_method(self):
+        prev = self.signal.value
+        while True:
+            await _scheduler.poll_event.wait()
+            now = self.signal.value
+            if prev.is_resolvable and now.is_resolvable and prev == 1 and now == 0:
+                break
+            prev = now
+
+
+class RisingEdge:
+    def __init__(self, signal):
+        self.signal = signal
+
+    def __await__(self):
+        return self._async_method().__await__()
+
+    async def _async_method(self):
+        prev = self.signal.value
+        while True:
+            await _scheduler.poll_event.wait()
+            now = self.signal.value
+            if prev.is_resolvable and now.is_resolvable and prev == 0 and now == 1:
+                break
+            prev = now
+
+
+class Edge:
+    def __init__(self, signal):
+        self.signal = signal
+
+    def __await__(self):
+        return self._async_method().__await__()
+
+    async def _async_method(self):
+        prev = self.signal.value
+        while True:
+            await _scheduler.poll_event.wait()
+            now = self.signal.value
+            if prev.is_resolvable and now.is_resolvable and prev != now:
+                break
+            prev = now

--- a/src/cocotb_vivado/mock_triggers.py
+++ b/src/cocotb_vivado/mock_triggers.py
@@ -8,7 +8,14 @@ shared timer, providing consistent timing behavior across the simulation.
 """
 
 import cocotb
+import warnings
 
+warnings.warn(
+    "mock_triggers is deprecated and will be removed in a future release; "
+    "use cocotb.clock.Clock() driver instead.",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 class TimerSingleton:
     """Singleton class that provides a single reusable Timer(100, "ns") instance."""

--- a/tests/test_axil.py
+++ b/tests/test_axil.py
@@ -6,8 +6,7 @@ import shutil
 
 import cocotb
 from cocotb.triggers import Timer
-
-import cocotb_vivado.mock_triggers
+from cocotb.clock import Clock
 
 from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiLiteRam
 
@@ -15,12 +14,8 @@ from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiLiteRam
 @cocotb.test()
 async def cocotb_axil_test(dut):
 
-    clk_period = 200
-    clk_timer = Timer(clk_period // 2, "ns")
-
-    cocotb_vivado.mock_triggers.set_timer(clk_timer)
-
-    cocotb.start_soon(cocotb_vivado.mock_triggers.clock(dut.clk))
+    clk = Clock(dut.clk, 200, units="ns")
+    cocotb.start_soon(clk.start())
 
     dut.rst.value = 1
     await Timer(500, "ns")

--- a/tests/test_fw.py
+++ b/tests/test_fw.py
@@ -6,8 +6,7 @@ import shutil
 
 import cocotb
 from cocotb.triggers import Timer
-
-import cocotb_vivado.mock_triggers
+from cocotb.clock import Clock
 
 from cocotbext.axi import AxiLiteBus, AxiLiteMaster
 from cocotbext.axi import AxiStreamSink, AxiStreamSource, AxiStreamBus
@@ -23,12 +22,8 @@ async def reset(signal, timer):
 async def cocotb_fw_test(dut):
     AXIS_FIFO_BASEADDR = 0x1000
 
-    clk_period = 200
-    clk_timer = Timer(clk_period // 2, "ns")
-
-    cocotb_vivado.mock_triggers.set_timer(clk_timer)
-
-    cocotb.start_soon(cocotb_vivado.mock_triggers.clock(dut.aclk))
+    clk = Clock(dut.aclk, 200, units="ns")
+    cocotb.start_soon(clk.start())
 
     cocotb.start_soon(reset(dut.areset, Timer(520, "ns")))
 


### PR DESCRIPTION
Align clock driver and edge trigger interface with standard cocotb practices for better compatibility.

I've been experimenting with cocotb-vivado for some time now, and the edge triggering in multi-clock designs seemed to be the biggest obstacle for my use cases. 

Ended up writing clock scheduler for performance reasons, as simply tightening the old mock_triggers' polling loop would make my simulations run for ages.

Feedback highly appreciated.