### PR TITLE
Python runner: packaging, examples, CI

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=v[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Behavioral change summary
+
+<!-- One paragraph describing the user-visible change. What can someone do
+after this PR that they couldn't do before, or what changes for someone
+who already uses cocotb-vivado? -->
+
+## Breaking changes
+
+<!-- Bullet list of removed kwargs, renamed APIs, default-value changes,
+etc. If none, say "None." -->
+
+## Local test output
+
+<!-- Paste the output of `pytest -s tests/<your_test>.py` (or the
+relevant subset). The CI runs lint only — it cannot exercise Vivado, so
+the reviewer relies on this paste for functional confidence. -->
+
+```
+<paste pytest -s output here>
+```
+
+## Documentation diff confirmed
+
+- [ ] `CHANGELOG.md` entry added under the appropriate heading
+- [ ] `MIGRATION.md` row added (if there's a breaking change)
+- [ ] Module docstrings added or updated on any new file
+- [ ] `README.md` updated (if user-facing surface changed)
+- [ ] `examples/` updated (if a new capability is worth showcasing)
+- [ ] `ruff check .` and `mypy src/` clean locally

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy
+          pip install -e .
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+      - name: Mypy
+        run: mypy src/

--- a/.gitignore
+++ b/.gitignore
@@ -128,14 +128,21 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+sim_build/
 xsim.dir
+xsim.jou
+*.pb
 xelab.*
 xvlog.*
 xvhdl.*
 *.wdb
 *.vcd
+*.fst
 vivado*.jou
 .vscode
 fw
 results.xml
 xsim.ini
+
+# setuptools-scm generated version
+src/cocotb_vivado/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+exclude: "^.*/_vendor/"
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.15.15"
+    hooks:
+      - id: "ruff"
+        args:
+          - "--fix"
+          - "--exit-non-zero-on-fix"
+      - id: ruff-format
+
+  - repo: "https://github.com/pre-commit/pre-commit-hooks"
+    rev: "v6.0.0"
+    hooks:
+      - id: "trailing-whitespace"
+      - id: "mixed-line-ending"
+        args:
+          - "--fix=lf"
+      - id: "end-of-file-fixer"
+
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: "2026.05.28"
+    hooks:
+      - id: validate-pyproject
+        files: pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `cocotb_vivado.runner` — a Python runner subclass of
+  `cocotb.runner.Simulator`. Reachable via
+  `cocotb_vivado.runner.get_runner("vivado")` and the standard
+  `runner.build()` / `runner.test()` interface. Pure XSim binary
+  orchestration: only `xelab` / `xvlog` / `xvhdl` are invoked
+  directly. Vivado-managed sources (`.xci`, `.bd`, `.xpr`) are out
+  of scope and land in a follow-up PR.
+- `cocotb_vivado.__main__` — subprocess entry point that
+  `runner.test()` spawns via `python -m cocotb_vivado`. Reads the
+  snapshot name and optional WDB output path from environment.
+- `wdb_file` kwarg threaded through `xsi.XSI.__init__` and
+  `stub.mgr.Mgr.init`, so the WDB output path can be set explicitly
+  by the runner instead of defaulting to `xsi.wdb` in the cwd.
+- `pyproject.toml` mirroring cocotb upstream's lint and type
+  configuration (ruff with the same extend-select / ignore set, mypy
+  in strict mode with per-module overrides for the legacy modules,
+  pytest with `--strict-markers`).
+- `.pre-commit-config.yaml` with `ruff --fix`, `ruff-format`, basic
+  whitespace/EOL fixers, and `validate-pyproject`.
+- GitHub Actions workflow `.github/workflows/lint.yml` running ruff
+  and mypy on every push/PR.
+- `CONTRIBUTING.md` describing the Linux-only dev setup, the
+  runner-stays-on-XSim-binaries architectural rule, and the
+  submission convention.
+- `CHANGELOG.md` (this file) and `MIGRATION.md` (before/after
+  guidance for users moving off the legacy `cocotb_vivado.run()`
+  path).
+- `.github/PULL_REQUEST_TEMPLATE.md` with required sections for
+  behavioral summary, breaking changes, local test output, and the
+  documentation-diff checklist.
+- `examples/counter/`, `examples/parameters/`, and `examples/ip/`
+  (placeholder until IP / BD / XPR support lands).
+- `tests/test_params.py` + `tests/tb_params.v` — verify top-level
+  Verilog parameter / VHDL generic pass-through to `xelab` via
+  `-generic_top`.
+
+### Changed
+
+- `tests/test_simple.py` and `tests/test_tb.py` rewritten on top of
+  `cocotb_vivado.runner.get_runner()`. Their legacy
+  `cocotb_vivado.run()`-based variants stay available but are
+  skip-gated behind `COCOTB_VIVADO_TEST_DIRECT=1`.
+- `tests/test_axil.py`, `tests/test_fw.py`, `tests/test_xsi.py`
+  module-level skip-gated behind `COCOTB_VIVADO_TEST_DIRECT=1` while
+  they still depend on the legacy direct-launch path. They will
+  migrate to the new runner alongside IP / BD / XPR support.
+- `setup.py` reduced to a thin shim; project metadata moved to the
+  `[project]` table in `pyproject.toml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to cocotb-vivado
+
+## Development environment
+
+cocotb-vivado is **Linux-only**. The package loads XSI shared libraries
+(`libxv_simulator_kernel.so`, `xsimk.so`) via ctypes; the XSI interface
+is Linux-specific and there are no plans to support Windows or macOS.
+
+You need:
+
+- Python 3.10 or newer.
+- A Linux install of Xilinx Vivado. Vivado 2023.1 is the minimum tested
+  version; newer ones are expected to work but verify locally.
+- `vcd2fst` from gtkwave (optional, only needed if you select
+  `wave_format="fst"`).
+
+Set up:
+
+```bash
+# Source your Vivado environment so xelab/xvlog/xvhdl/vivado are on PATH.
+# Note settings64.sh does NOT export LD_LIBRARY_PATH on every install --
+# export it yourself so the XSI shared libraries can be dlopened:
+source /path/to/Vivado/<version>/settings64.sh
+export LD_LIBRARY_PATH=$XILINX_VIVADO/lib/lnx64.o
+
+# Editable install of the project + test and dev dependencies
+pip install -e ".[dev]"
+
+# (Optional) install pre-commit hooks so the linters run on every commit
+pre-commit install
+```
+
+## Running tests
+
+```bash
+cd tests
+pytest -s test_simple.py        # one test
+pytest -s                       # the whole suite
+```
+
+Tests spawn `python -m cocotb_vivado` as a subprocess that loads XSI in
+process. The Vivado binaries must be reachable on `PATH`. For those tests
+`LD_LIBRARY_PATH` need not be set in your shell -- the runner exports it
+for the subprocess, synthesizing it from `XILINX_VIVADO` when absent.
+
+`tests/test_xsi.py` is the exception: it dlopens `xsimk.so` *in the pytest
+process* via ctypes, so it needs `LD_LIBRARY_PATH` exported **before**
+Python starts. Setting it from inside the process does not work -- the
+dynamic loader captures its search path at exec time. The test skips
+itself with an explanatory message when the XSI kernel library is not
+loadable, so a missing `LD_LIBRARY_PATH` is a skip, not a failure.
+
+`tests/test_fw.py` still exercises the legacy `cocotb_vivado.run()` path
+and is skipped by default pending its migration to the runner; set
+`COCOTB_VIVADO_TEST_DIRECT=1` to run it. Everything else runs
+unconditionally.
+
+## Linting and type checking
+
+```bash
+ruff check .
+ruff format --check .
+mypy src/
+```
+
+`pre-commit run --all-files` runs all of the above plus the basic
+whitespace / line-ending hooks.
+
+## Architectural rule
+
+**`cocotb_vivado.runner` invokes only the XSim binaries** (`xelab` /
+`xvlog` / `xvhdl`). The full `vivado` tool is not invoked from this
+module — that surface (TCL execution, IP regeneration, project export,
+part discovery) belongs to a separate module introduced in a follow-up
+PR alongside support for Vivado-managed sources (`.xci`, `.bd`, `.xpr`).
+
+## Why a separate package, not upstream cocotb
+
+Reasonable question to ask once. The short answer:
+
+- **Vivado XSim does not expose VPI or VHPI.** Every cocotb upstream
+  simulator backend (Icarus, Verilator, Questa, GHDL, Riviera,
+  Xcelium, NVC) talks to its simulator through VPI / VHPI / FLI via a
+  cocotb-maintained C shim. Vivado ships only XSI — a low-level
+  kernel API with no value-change callback registration. `xelab` has
+  no `-loadvpi` equivalent. It's an architectural mismatch, not a
+  missing-feature gap.
+- **The XSI workarounds don't generalize.** `clock_scheduler.py`'s
+  Timer-polled edge triggers, the `sys.modules["cocotb.simulator"]`
+  patch, and the `python -m cocotb_vivado` subprocess pattern exist
+  *because* XSI can't deliver callbacks. They're a XSim-shaped crutch
+  with no reuse in any other simulator context.
+- **Vivado tool integration (TCL, IP regeneration, project export)
+  is vendor-specific** and doesn't belong in cocotb core.
+- **No community signal.** No issues in the cocotb/cocotb repo
+  mention Vivado, XSim, or Xilinx.
+- **Independent release cadence.** Vivado-specific tooling iterates
+  on Xilinx releases, not cocotb releases.
+
+The cocotb-blessed pattern for external simulator backends is exactly
+what this package does: subclass `cocotb.runner.Simulator`, ship as a
+third-party package, register via the project's own `get_runner()`
+shim. No fork of cocotb internals; just a backend that follows the
+documented integration pattern.
+
+## Submitting changes
+
+- Open PRs against `main`.
+- Use the PR template in `.github/PULL_REQUEST_TEMPLATE.md`.
+- Every PR must update `CHANGELOG.md` under the appropriate heading
+  (`### Added` / `### Changed` / `### Removed` / `### Fixed`). If the
+  PR introduces a breaking change, add a row to `MIGRATION.md` as well.
+- New public symbols need module / class / function docstrings stating
+  their contract (parameters, return value, raises, notable side
+  effects). Type hints carry the rest — don't duplicate type
+  information in docstring prose.
+- Keep comments short and focused on intent. Don't describe history
+  (no "previously this returned X" / "renamed from Y"); that belongs
+  in commit messages and CHANGELOG.
+
+## License
+
+By contributing, you agree your contributions are licensed under the
+[Apache License 2.0](LICENSE).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,105 @@
+# Migration guide
+
+This document describes how to move existing cocotb-vivado tests onto
+the new Python runner API.
+
+## From the legacy `cocotb_vivado.run()` direct-launch path
+
+Existing tests build the simulator binary themselves by spawning
+`xvlog` / `xelab` as subprocesses, then call `cocotb_vivado.run()` to
+load the resulting `.so` and execute the cocotb regression:
+
+```python
+import cocotb_vivado
+import subprocess
+import shutil
+import pathlib
+
+def test_simple():
+    src_path = pathlib.Path(__file__).parent.absolute()
+    shutil.rmtree("xsim.dir", ignore_errors=True)
+    if not os.path.exists("xsim.dir/work.tb/xsimk.so"):
+        subprocess.run(["xvlog", src_path / "tb.v"])
+        subprocess.run(["xelab", "work.tb", "-dll"])
+    cocotb_vivado.run(
+        module="test_simple",
+        xsim_design="xsim.dir/work.tb/xsimk.so",
+        top_level_lang="verilog",
+    )
+```
+
+The new path moves the build/elab orchestration into a
+`cocotb.runner.Simulator` subclass:
+
+```python
+import os
+from pathlib import Path
+from cocotb_vivado.runner import get_runner
+
+def test_simple():
+    proj_path = Path(__file__).resolve().parent
+    runner = get_runner(os.getenv("SIM", "vivado"))
+    runner.build(
+        sources=[proj_path / "tb.v"],
+        hdl_toplevel="tb",
+        always=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="tb",
+        test_module="test_simple",
+        hdl_toplevel_lang="verilog",
+        testcase="simple_test",
+    )
+```
+
+Both paths coexist for now. The legacy `cocotb_vivado.run()` function
+remains importable; the new runner is the recommended path going
+forward. The existing in-tree tests have been updated as follows:
+
+- `tests/test_simple.py` and `tests/test_tb.py` now use the new runner
+  by default. Their legacy variants are kept under
+  `@pytest.mark.skipif(... COCOTB_VIVADO_TEST_DIRECT=1 ...)` for
+  regression coverage.
+- `tests/test_axil.py`, `tests/test_fw.py`, and `tests/test_xsi.py`
+  are skip-gated at the module level behind the same env var. They
+  will move to the new runner alongside IP / BD / XPR support.
+
+## Environment
+
+Before running tests:
+
+- `xelab` / `xvlog` / `xvhdl` must be on `PATH` (source your Vivado
+  `settings64.sh`).
+- `LD_LIBRARY_PATH` must be set so the in-process XSI shared library
+  can be loaded by the test subprocess. If unset, the runner falls
+  back to constructing one from `XILINX_VIVADO`.
+
+## Waveform output
+
+The new runner takes an explicit `wave_format` kwarg on
+`runner.build()` / `runner.test()`:
+
+```python
+runner.build(..., wave_format="vcd")      # Verilog $dumpfile/$dumpvars
+runner.build(..., wave_format="fst")      # VCD then post-processed by vcd2fst
+runner.build(..., wave_format="wdb")      # Vivado native
+runner.build(...)                          # default: no waves
+```
+
+All three formats land at `{build_dir}/{hdl_toplevel}.{ext}` for
+symmetry. `wave_format="fst"` auto-downgrades to `"vcd"` with a warning
+when `vcd2fst` is not on `PATH`.
+
+## Tested Vivado versions
+
+The runner is tested against Vivado **2023.1** as the minimum supported
+version. Newer Vivado versions are expected to work but may have
+version-specific quirks; see the project README for currently verified
+versions.
+
+## Platform support
+
+Linux only. cocotb-vivado loads XSI shared libraries
+(`libxv_simulator_kernel.so`, `xsimk.so`) via ctypes; the XSI
+interface is Linux-specific.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,63 @@
 # cocotb-vivado
+
 [![PyPI version](https://badge.fury.io/py/cocotb-vivado.svg)](https://pypi.org/project/cocotb-vivado/)
+[![lint](https://github.com/themperek/cocotb-vivado/actions/workflows/lint.yml/badge.svg)](https://github.com/themperek/cocotb-vivado/actions/workflows/lint.yml)
 
-A limited Python/[cocotb](https://github.com/cocotb/cocotb/) interface to the [Xilinx Vivado Simulator](https://docs.xilinx.com/v/u/en-US/dh0010-vivado-simulation-hub) simulator. 
+A Python/[cocotb](https://github.com/cocotb/cocotb/) interface to the
+[Xilinx Vivado Simulator](https://docs.xilinx.com/v/u/en-US/dh0010-vivado-simulation-hub).
+
 Based on [cocotb-stub-sim](https://github.com/fvutils/cocotb-stub-sim).
+The Python runner and the value-change manager are derived from
+[vicoco](https://github.com/kiran-vuksanaj/vicoco) by Kiran Vuksanaj.
 
 ---
 
-## 🚧 Project Status
-**Proof of Concept** – expect limitations (see below).  
+## Project status
 
-- Only top-level ports are accessible (simulator limitation).  
-- Edge-triggers `Edge`, `RisingEdge`, `FallingEdge` only work on clocks generated in the testbench/python with cocotb.clock.Clock() driver." (simulator limitation, see below).
-- Setting signal values is immediate (`setimmediatevalue` behavior).  
-- Only **Verilog top-levels** are supported (VHDL support planned).  
-- Direct access to the **XSI interface** is available.  
+**Active development.** The Python runner experience is being rebuilt.
+See [CHANGELOG.md](CHANGELOG.md) for what's landed and
+[MIGRATION.md](MIGRATION.md) for breaking changes.
 
----
+Known limitations:
+
+- Only top-level ports are accessible (XSI limitation).
+- Edge triggers (`Edge`, `RisingEdge`, `FallingEdge`) only fire on
+  clocks driven by `cocotb.clock.Clock()` in the testbench. Native
+  value-change callbacks are not supported by the XSI stub today;
+  the scheduler-driven stand-ins from
+  `cocotb_vivado.clock_scheduler` cover only Python-driven signals.
+- Setting signal values is immediate (`setimmediatevalue` behavior).
+- VHDL top-level support is in progress; today's release runs Verilog
+  tops cleanly and accepts VHDL sources.
+- Direct access to the **XSI interface** via `cocotb_vivado.xsi` is
+  available for low-level tooling.
+
+## Platform support
+
+**Linux only.** cocotb-vivado loads XSI shared libraries via ctypes;
+the XSI interface is Linux-specific.
+
+## Tested Vivado versions
+
+- Vivado **2023.1** — minimum supported.
+- Newer versions are expected to work but verify locally.
 
 ## Installation
 
 ```bash
-pip install cocotb-vivado==0.0.3 (for VIVADO <= 2022.2)
-pip install cocotb-vivado (for VIVADO >= 2023.1)
+pip install cocotb-vivado
 ```
 
 ## Quickstart
 
 ```python
-import subprocess
+from pathlib import Path
 
-import cocotb_vivado
 import cocotb
 from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
+
 
 @cocotb.test()
 async def simple_test(dut):
@@ -41,58 +67,111 @@ async def simple_test(dut):
     await Timer(10, units="ns")
     assert dut.out.value == 1
 
-def test_simple():
-    subprocess.run(["xvlog", "tb.v"])
-    subprocess.run(["xelab", "work.tb", "-dll"])
 
-    cocotb_vivado.run(module="test_simple", xsim_design="xsim.dir/work.tb/xsimk.so", top_level_lang="verilog")
+def test_simple():
+    runner = get_runner("vivado")
+    runner.build(
+        sources=[Path(__file__).parent / "tb.v"],
+        hdl_toplevel="tb",
+        always=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="tb",
+        test_module="test_simple",
+        hdl_toplevel_lang="verilog",
+        testcase="simple_test",
+    )
 ```
 
-See `testes/test_simple.py` for full example.
+See [`examples/`](examples/) for runnable projects and the `tests/`
+directory for more scenarios.
 
-## Usage
-
-See the `tests` folder for examples.
+Before running:
 
 ```bash
-source ../Vivado/202X.X/settings64.sh
-export LD_LIBRARY_PATH=$XILINX_VIVADO/lib/lnx64.o
-pytest -s
+source /path/to/Vivado/<version>/settings64.sh
+pytest -s tests/
 ```
 
-Extra feature: One does not need to recompile the project when running/changing tests .
+`xelab` / `xvlog` / `xvhdl` must be on `PATH` and `LD_LIBRARY_PATH`
+must be set (or `XILINX_VIVADO` set as a courtesy fallback so the
+runner can synthesize one for the test subprocess).
 
-## Direct `XSI` interface
+## Import order caveat
 
-You can use `XSI` interface directly see `tests/test_xsi.py` for an example.
+Importing `cocotb_vivado` has two global side effects:
 
-## Overcoming `XSI` limitations
+1. It replaces `cocotb.simulator` in `sys.modules` with the in-process
+   XSI stub.
+2. It replaces `cocotb.clock.Clock` and the
+   `cocotb.triggers.{RisingEdge, FallingEdge, Edge}` classes with
+   scheduler-driven polling stand-ins from
+   `cocotb_vivado.clock_scheduler`. The XSI stub does not support
+   value-change callbacks, so cocotb's native edge triggers cannot fire
+   — these stand-ins bridge the gap. A global `ClockScheduler`
+   singleton owns this state: patched `Clock` objects register
+   themselves with the scheduler, which drives the signals and
+   evaluates pending edge triggers on every clock-driven transition.
 
-`XSI` interface natively supports only `Timer` trigger.
+Consequence: **always import `cocotb_vivado` (or any `cocotb_vivado.*`
+submodule) before `cocotb`**.
 
-To allow for using edge triggers under this limitation, cocotb-vivado  provides its custom trigger mechanism. When `cocotb_vivado` is imported, a global ClockScheduler singleton is created. This scheduler replaces cocotb’s standard implementations of `Clock`, `Edge`, `RisingEdge`, and `FallingEdge`.
+```python
+# Correct
+import cocotb_vivado
+from cocotb_vivado.runner import get_runner
 
-The monkey‑patched Clock objects register themselves with the scheduler, which drives the associated signals and observes every resulting transition. On each clock‑driven edge, the scheduler evaluates all pending edge triggers and resumes any coroutines waiting on them. This polling‑on‑edge model gives deterministic behavior for multiple clocks while keeping the standard cocotb coroutine interface unchanged.
+import cocotb
+from cocotb.triggers import Timer
+from cocotb.clock import Clock
+```
+
+```python
+# Broken — cocotb caches the real simulator before our patch lands
+import cocotb
+import cocotb_vivado
+```
+
+Reference the patched triggers via the module path inside your test so
+the patch wins:
+
+```python
+@cocotb.test()
+async def t(dut):
+    await cocotb.triggers.RisingEdge(dut.clk)   # uses the patched class
+```
+
+`from cocotb.triggers import RisingEdge` followed by `RisingEdge(...)`
+binds the *original* class regardless of the patches, because Python
+resolves the name at import time.
+
+## Waveform output
+
+The `wave_format` kwarg on `runner.build()` / `runner.test()` selects
+the dump format:
+
+```python
+runner.build(..., wave_format="vcd")      # Verilog $dumpfile/$dumpvars
+runner.build(..., wave_format="fst")      # VCD post-processed by vcd2fst
+runner.build(..., wave_format="wdb")      # Vivado native, viewable in xsim --gui
+runner.build(...)                          # default: no waves
+```
+
+All formats land in `{build_dir}/{hdl_toplevel}.{ext}` for symmetry.
 
 ## cocotb extensions
 
-In order to use cocotb extension like [cocotbext-axi](https://github.com/alexforencich/cocotbext-axi) one needs to use `Clock` driver for clocking their DUT.
+Extensions like [cocotbext-axi](https://github.com/alexforencich/cocotbext-axi)
+work as long as the DUT is clocked by a Python-driven `Clock` — see
+the Import order caveat for why. AXI bus accesses are routed through
+the cocotb scheduler the extension expects.
 
-## Full Vivado design simulation
+## Contributing
 
-In order order to simulate full design you need create design, `export_simulation` files compile, elaborate and run. See `tests/fw.tcl` and `tests/test_fw.tcl` for an example.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Dump waveforms
+## Acknowledgment
 
-You can dump `vcd` file with verilog syntax in your testbench:
-
-```verilog
-initial begin
-    $dumpfile("test.vcd");
-    $dumpvars(0);
-end
-```
-
-### Acknowledgment
-
-We'd like to thank our employer, [Dectris](https://dectris.com/) for supporting this work.
+We'd like to thank our employer, [Dectris](https://dectris.com/) for
+supporting this work.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+Runnable cocotb-vivado projects, each self-contained with its own DUT
+sources, cocotb test, and a short README explaining what it
+demonstrates.
+
+| Example | Topic |
+|---------|-------|
+| [counter](counter/)       | Minimal "hello world": runner build + test of a synchronous counter |
+| [parameters](parameters/) | Sweep a top-level Verilog parameter via `runner.build(parameters=...)` |
+| [ip](ip/)                 | IP / BD / XPR (placeholder for the upcoming runner-based IP scenario) |
+
+All examples assume the Vivado environment is sourced (`xelab` /
+`xvlog` / `xvhdl` on `PATH`, `LD_LIBRARY_PATH` set):
+
+```bash
+source /path/to/Vivado/<version>/settings64.sh
+cd examples/<dir>
+pytest -s
+```
+
+For development setup and architectural rules, see
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,20 @@
+# counter
+
+The minimal "hello world" example: an 8-bit synchronous up-counter with
+a reset, driven by a cocotb test that verifies the output increments
+every clock edge.
+
+## What this example demonstrates
+
+- The minimum cocotb-vivado runner invocation: `get_runner("vivado")` →
+  `build()` → `test()`.
+- A `@cocotb.test()` function as the testbench body, with a
+  `cocotb.clock.Clock` driving the design's clock.
+
+## Run
+
+```bash
+source /path/to/Vivado/<version>/settings64.sh
+cd examples/counter
+pytest -s test_counter.py
+```

--- a/examples/counter/counter.v
+++ b/examples/counter/counter.v
@@ -1,0 +1,14 @@
+module counter (
+    input clk,
+    input rst,
+    output reg [7:0] q
+);
+
+    always @(posedge clk or posedge rst) begin
+        if (rst)
+            q <= 8'd0;
+        else
+            q <= q + 1;
+    end
+
+endmodule

--- a/examples/counter/test_counter.py
+++ b/examples/counter/test_counter.py
@@ -1,0 +1,54 @@
+"""Hello-world example: drive an 8-bit counter for a few cycles."""
+
+import os
+from pathlib import Path
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
+
+
+@cocotb.test()
+async def counter_increments(dut):
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start(start_high=False))
+
+    # The clock starts low, so rising edges land at t = 5, 15, 25, ... ns.
+    # cocotb applies value deposits before the simulator evaluates a timestep,
+    # so releasing reset at exactly t = 25 ns would already be visible to that
+    # edge and the counter would start one cycle early. Release between edges
+    # instead, which makes t = 35 ns plainly the first counted edge.
+    dut.rst.value = 1
+    await Timer(27, units="ns")
+    dut.rst.value = 0
+    await Timer(3, units="ns")
+
+    expected = 0
+    for _ in range(8):
+        await Timer(10, units="ns")
+        expected = (expected + 1) & 0xFF
+        assert int(dut.q.value) == expected, (
+            f"expected q={expected}, got {int(dut.q.value)}"
+        )
+
+
+def test_counter():
+    here = Path(__file__).resolve().parent
+    runner = get_runner(os.getenv("SIM", "vivado"))
+    runner.build(
+        sources=[here / "counter.v"],
+        hdl_toplevel="counter",
+        always=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="counter",
+        test_module="test_counter",
+        hdl_toplevel_lang="verilog",
+        testcase="counter_increments",
+    )
+
+
+if __name__ == "__main__":
+    test_counter()

--- a/examples/ip/README.md
+++ b/examples/ip/README.md
@@ -1,0 +1,10 @@
+# ip (placeholder)
+
+A runnable IP / BD / XPR example will land here once
+`cocotb_vivado.vivado` grows IP synthesis, part discovery, and
+Vivado project export support.
+
+Until then, see `tests/test_fw.py` on the upstream `main` branch for
+the legacy `cocotb_vivado.run()`-based IP/BD example, or
+`tests/test_axil.py` for the runner-based pattern on an AXI-Lite RTL
+design (no IP, exercised through `cocotbext.axi`).

--- a/examples/parameters/README.md
+++ b/examples/parameters/README.md
@@ -1,0 +1,24 @@
+# parameters
+
+Sweep a top-level Verilog parameter through the Python runner. The DUT
+is a pass-through with a parameterized vector width; pytest's
+`@pytest.mark.parametrize` drives `runner.build(parameters=...)` with
+WIDTH ∈ {8, 16, 32, 64}, and the cocotb test reads `len(dut.vec_out)`
+to verify the elaborated width matches.
+
+## What this example demonstrates
+
+- `runner.build(parameters={"WIDTH": w})` forwarding values to xelab as
+  `-generic_top WIDTH=w`.
+- Pytest parametrization driving multiple build/test cycles from a
+  single test source.
+- Reading the elaborated width inside the cocotb test via
+  `len(dut.vec_out)`.
+
+## Run
+
+```bash
+source /path/to/Vivado/<version>/settings64.sh
+cd examples/parameters
+pytest -s test_parameters.py
+```

--- a/examples/parameters/params_dut.v
+++ b/examples/parameters/params_dut.v
@@ -1,0 +1,10 @@
+module params_dut #(
+    parameter WIDTH = 8
+) (
+    input  [WIDTH-1:0] vec_in,
+    output [WIDTH-1:0] vec_out
+);
+
+    assign vec_out = vec_in;
+
+endmodule

--- a/examples/parameters/test_parameters.py
+++ b/examples/parameters/test_parameters.py
@@ -1,0 +1,53 @@
+"""Sweep a top-level Verilog parameter from the Python runner.
+
+Demonstrates ``runner.build(parameters=...)`` forwarding values to xelab
+via ``-generic_top``. The cocotb test reads the resulting bit width from
+the elaborated design.
+"""
+
+import os
+from pathlib import Path
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
+
+
+@cocotb.test()
+async def check_width(dut):
+    expected = int(os.environ["EXPECTED_WIDTH"])
+    await Timer(1, "ns")
+    assert len(dut.vec_out) == expected, (
+        f"expected vec_out width {expected}, got {len(dut.vec_out)}"
+    )
+
+
+def _run(width):
+    os.environ["EXPECTED_WIDTH"] = str(width)
+    here = Path(__file__).resolve().parent
+    runner = get_runner(os.getenv("SIM", "vivado"))
+    runner.build(
+        sources=[here / "params_dut.v"],
+        hdl_toplevel="params_dut",
+        always=True,
+        parameters={"WIDTH": width},
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="params_dut",
+        test_module="test_parameters",
+        hdl_toplevel_lang="verilog",
+        testcase="check_width",
+    )
+
+
+@pytest.mark.parametrize("width", [8, 16, 32, 64])
+def test_width_sweep(width):
+    _run(width)
+
+
+if __name__ == "__main__":
+    for w in (8, 16, 32, 64):
+        _run(w)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,3 +162,6 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
+markers = [
+    "in_process_xsi: dlopens xsimk.so in the pytest process; needs LD_LIBRARY_PATH exported before Python starts",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,164 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cocotb-vivado"
+dynamic = ["version"]
+description = "Limited cocotb/Python interface for Xilinx Vivado Simulator"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Tomasz Hemperek", email = "themperek@gmail.com" },
+]
+keywords = ["SystemVerilog", "Verilog", "RTL", "cocotb", "Python", "Vivado", "Xilinx", "xsim", "xsi"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Framework :: cocotb",
+]
+requires-python = ">=3.10"
+dependencies = [
+    "cocotb>=1.8,<2.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/themperek/cocotb-vivado"
+
+[tool.setuptools_scm]
+# Version is derived from the latest git tag (e.g. ``v0.1.0``), so a
+# GitHub release/tag is the single source of truth. The resolved version
+# is written into the package at build time (``_version.py``) so built
+# wheels/sdists carry it without git; ``.git_archival.txt`` +
+# ``.gitattributes`` let a ``git archive`` tarball (what GitHub generates
+# for a release) carry it too. ``fallback_version`` keeps a git-less,
+# archive-less checkout from failing the build.
+version_file = "src/cocotb_vivado/_version.py"
+fallback_version = "0.0.0"
+# Only ``v``-prefixed release tags drive the version, so unrelated tags
+# (e.g. review checkpoints) are ignored.
+git_describe_command = [
+    "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
+
+[project.optional-dependencies]
+# Test-only dependencies. tests/test_axil.py, tests/test_bd_axi.py and
+# tests/test_fw.py drive the DUT with cocotbext-axi; without this extra a
+# fresh clone fails at collection, before any simulation runs.
+test = [
+    "cocotbext-axi",
+    "pytest",
+]
+dev = [
+    "cocotb-vivado[test]",
+    "ruff",
+    "mypy",
+    "pre-commit",
+]
+
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+extend-exclude = [
+    "venv",
+    ".venv*",
+    "build",
+    "dist",
+]
+target-version = "py39"
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+extend-select = [
+    "I",        # isort
+    "UP",       # pyupgrade
+    "PL",       # pylint
+    "E",        # pycodestyle errors
+    "W",        # pycodestyle warnings
+    "F",        # pyflakes
+    "C4",       # flake8-comprehension
+    "LOG",      # flake8-logging
+    "G",        # flake8-logging-format
+    "ISC",      # implicit string concat
+    "TC",       # flake8-typechecking
+    "SIM103",   # return the condition directly
+    "SIM300",   # yoda conditions
+    "RUF100",   # unused noqa
+    "RUF101",   # redirected noqa
+    "RUF010",   # explicit type conversion in f-string
+    "RUF005",   # collection literal concatenation
+    "RUF022",   # unsorted __all__
+    "PERF101",  # unnecessary list cast
+    "PERF102",  # unnecessary dict.items()
+    "B007",     # unused loop variable
+    "PYI030",   # unnecessary literal union
+]
+ignore = [
+    "E741",    # ambiguous variable name (preference)
+    "E501",    # line too long (preference)
+    "PLR0912", # Too many branches (>12) (preference)
+    "PLR0913", # Too many arguments to function call (>5) (preference)
+    "PLR0915", # Too many statements (>50) (preference)
+    "PLR2004", # Magic value used in comparison (preference)
+    "PLW0603", # Using the global statement (preference)
+    "PLR0911", # Too many return statements (preference)
+    "PLW1641", # __eq__ without __hash__ (mypy compatibility)
+    "TC001",   # typing-only first party import
+    "TC002",   # typing-only third party import
+    "TC003",   # typing-only standard library import
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["cocotb_vivado"]
+
+[tool.ruff.lint.per-file-ignores]
+# Legacy run()-based tests. They keep their original bare subprocess
+# invocations and identity comparisons verbatim until they migrate to
+# the new runner.
+"tests/test_axil.py" = ["PLW1510", "F841"]
+"tests/test_fw.py" = ["PLW1510"]
+"tests/test_xsi.py" = ["PLW1510", "E712"]
+
+[tool.mypy]
+python_version = "3.11"
+packages = ["cocotb_vivado"]
+mypy_path = "src/"
+disallow_untyped_defs = true
+disallow_any_unimported = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+implicit_reexport = false
+show_error_codes = true
+pretty = true
+allow_redefinition = true
+
+# Legacy modules pre-dating the runner-first refactor; cleaned up incrementally.
+[[tool.mypy.overrides]]
+module = [
+    "cocotb_vivado",
+    "cocotb_vivado.xsi",
+    "cocotb_vivado.mock_triggers",
+    "cocotb_vivado.clock_scheduler",
+    "cocotb_vivado.stub.*",
+]
+ignore_errors = true
+
+# cocotb has no public py.typed marker on the 1.x line we target.
+[[tool.mypy.overrides]]
+module = ["cocotb", "cocotb.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,3 @@
-from setuptools import setup, find_packages
-from pathlib import Path
+from setuptools import setup
 
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
-
-setup(
-    name="cocotb-vivado",
-    version="0.0.5",
-    install_requires=["cocotb>=1.8,<2.0"],
-    packages=find_packages(where="./src"),
-    package_dir={"": "src"},
-    author="Tomasz Hemperek",
-    author_email="themperek@gmail.com",
-    description="Limited cocotb/Python interface for Xilinx Vivado Simulator",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="Apache 2.0",
-    keywords=["SystemVerilog", "Verilog", "RTL", "cocotb", "Python", "Vivado", "Xilinx", "xsim", "xsi"],
-    url="https://github.com/themperek/cocotb-vivado",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-        "Framework :: cocotb",
-    ],
-    platforms="any",
-)
+setup()

--- a/src/cocotb_vivado/__init__.py
+++ b/src/cocotb_vivado/__init__.py
@@ -1,25 +1,80 @@
-import sys
+"""cocotb-vivado package init.
+
+Importing this package has two global side effects:
+
+1. ``cocotb.simulator`` in ``sys.modules`` is replaced with the
+   in-process XSI stub. This is how the runner injects a GPI shim
+   that cocotb can talk to.
+2. ``cocotb.clock.Clock`` and the ``cocotb.triggers.{Edge, RisingEdge,
+   FallingEdge}`` classes are replaced with scheduler-driven polling
+   equivalents from :mod:`cocotb_vivado.clock_scheduler`. The stub
+   rejects ``register_value_change_callback``, so the real cocotb edge
+   triggers cannot work; the polling stand-ins fill that gap until the
+   stub layer learns proper value-change callbacks.
+
+Consequence — **import order matters**. Always import ``cocotb_vivado``
+(or any ``cocotb_vivado.*`` submodule) before ``cocotb``. Importing
+``cocotb`` first caches the real C-extension simulator and the patch
+silently becomes a no-op:
+
+.. code-block:: python
+
+    # Correct
+    import cocotb_vivado
+    from cocotb_vivado.runner import get_runner
+    import cocotb
+
+    # Broken — cocotb caches the real simulator before our patch lands
+    import cocotb
+    import cocotb_vivado
+
+For the trigger patches to win, reference the trigger classes via the
+module path inside your test:
+
+.. code-block:: python
+
+    @cocotb.test()
+    async def t(dut):
+        await cocotb.triggers.RisingEdge(dut.clk)  # uses the patched class
+
+``from cocotb.triggers import RisingEdge`` followed by ``RisingEdge(...)``
+binds the *original* class regardless of these patches, because Python
+resolves the name at import time.
+
+Both side effects are tracked for removal once the stub layer ships
+proper value-change callback support, at which point the trigger
+patches go away and cocotb's native edge triggers Just Work.
+"""
+
 import importlib
-import traceback
 import os
+import sys
 
-sys.modules["cocotb.simulator"] = importlib.import_module("cocotb_vivado.stub.simulator")
+# Replace cocotb.simulator BEFORE cocotb is imported so the GPI shim is
+# in place when cocotb wires up its callbacks.
+sys.modules["cocotb.simulator"] = importlib.import_module(
+    "cocotb_vivado.stub.simulator"
+)
 
-import cocotb
+import cocotb  # noqa: E402
+import cocotb.clock  # noqa: E402
+import cocotb.triggers  # noqa: E402
 
-# monkey-patch the clock & trigger layer
-import cocotb.clock
-import cocotb.triggers
-from .clock_scheduler import ScheduledClock, RisingEdge, FallingEdge, Edge
-cocotb.clock.Clock = ScheduledClock
+from . import clock_scheduler  # noqa: E402
+from .stub.mgr import Mgr  # noqa: E402
+
+# Patch cocotb's Clock and edge-trigger classes with scheduler-driven
+# stand-ins. The XSI stub does not support value-change callbacks, so
+# cocotb's native RisingEdge/FallingEdge/Edge cannot fire; the polling
+# implementations from clock_scheduler bridge the gap.
+cocotb.clock.Clock = clock_scheduler.ScheduledClock
 cocotb.triggers.RisingEdge = clock_scheduler.RisingEdge
 cocotb.triggers.FallingEdge = clock_scheduler.FallingEdge
 cocotb.triggers.Edge = clock_scheduler.Edge
 
-from .stub.mgr import Mgr
-
 
 def run(module, xsim_design, top_level_lang):
+    """Legacy direct-launch entry; superseded by ``cocotb_vivado.runner.Vivado``."""
     if top_level_lang != "verilog":
         raise Exception("Only verilog supported as top level languge")
 
@@ -34,4 +89,4 @@ def run(module, xsim_design, top_level_lang):
     mgr.close()
 
     if cocotb.regression_manager.failures:
-        exit(1)
+        sys.exit(1)

--- a/src/cocotb_vivado/__main__.py
+++ b/src/cocotb_vivado/__main__.py
@@ -1,0 +1,58 @@
+# Copyright cocotb-vivado contributors
+# Copyright 2026 Kiran Vuksanaj
+# Licensed under the Apache License 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from vicoco's subprocess entry point
+# (https://github.com/kiran-vuksanaj/vicoco).
+
+"""Subprocess entry point invoked by :meth:`Vivado.test`.
+
+The runner spawns ``python -m cocotb_vivado`` after build, passing the
+snapshot name and (optionally) the WDB output path via environment
+variables. This module patches ``cocotb.simulator`` to point at the
+in-process XSI stub, initializes the simulator manager, runs the
+cocotb regression, and exits with the regression's pass/fail status.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from sys import argv
+
+# The stub must replace cocotb.simulator BEFORE cocotb itself is imported,
+# so the GPI shim is in place when cocotb wires up its callbacks.
+sys.modules["cocotb.simulator"] = importlib.import_module(
+    "cocotb_vivado.stub.simulator"
+)
+
+import cocotb  # noqa: E402
+
+from .stub.mgr import Mgr  # noqa: E402
+
+
+def _initialize_simulator(
+    argv_: list[str], xsim_design: str, wdb_file: str | None = None
+) -> None:
+    mgr = Mgr.init(xsim_design, wdb_file=wdb_file)  # type: ignore[no-untyped-call]
+    cocotb._initialise_testbench([])
+    mgr.run()
+    mgr.close()
+    if cocotb.regression_manager.failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    snapshot_name = os.getenv("VIVADO_SNAPSHOT_NAME")
+    if not snapshot_name:
+        raise SystemExit(
+            "ERROR: VIVADO_SNAPSHOT_NAME is unset. "
+            "Launch via cocotb_vivado.runner.Vivado.test(), not directly."
+        )
+
+    design_so_file = f"xsim.dir/{snapshot_name}/xsimk.so"
+    wdb_file = os.getenv("VIVADO_WDB_FILE") or None
+
+    _initialize_simulator(argv, design_so_file, wdb_file=wdb_file)

--- a/src/cocotb_vivado/clock_scheduler.py
+++ b/src/cocotb_vivado/clock_scheduler.py
@@ -1,14 +1,11 @@
 import logging
-import typing
-from collections import defaultdict
 from decimal import Decimal
 from numbers import Real
 
-import cocotb.clock
 from cocotb import start_soon
-from cocotb.utils import get_sim_steps, get_time_from_sim_steps, get_sim_time
 from cocotb.task import Task
-from cocotb.triggers import Timer, Event
+from cocotb.triggers import Event, Timer
+from cocotb.utils import get_sim_steps, get_sim_time, get_time_from_sim_steps
 
 
 class ScheduledClock:
@@ -17,7 +14,8 @@ class ScheduledClock:
 
     Mimicing cocotb v1.9.2 interface, although cycle count mechanism is deprecated in v2.0.0
     """
-    def __init__(self, signal, period: float|Real|Decimal, units: str = "step"):
+
+    def __init__(self, signal, period: float | Real | Decimal, units: str = "step"):
         self.signal = signal
         self.period = get_sim_steps(period, units)
         self.frequency = 1 / get_time_from_sim_steps(self.period, units="us")
@@ -28,8 +26,8 @@ class ScheduledClock:
         self._start_time = 0
         self._stop_event = Event()
 
-    async def start(self, cycles: int|None = None, start_high: bool = True):
-        """ Start the clock by adding it to the scheduler's clock collection. """
+    async def start(self, cycles: int | None = None, start_high: bool = True):
+        """Start the clock by adding it to the scheduler's clock collection."""
         self.cycles = cycles
         self._remaining_cycles = self.cycles
         self.start_high = start_high
@@ -46,11 +44,11 @@ class ScheduledClock:
         _scheduler.remove_clock(self)
 
     def _drive_signal(self, new_value: bool):
-        """ Set clock signal state """
+        """Set clock signal state"""
         if self._remaining_cycles is not None:
             current_value = self.signal.value
             if current_value.is_resolvable:
-                if current_value  ^ self.start_high and not new_value:
+                if current_value ^ self.start_high and not new_value:
                     # falling edge, reduce the cycle count
                     self._remaining_cycles -= 1
                 if self._remaining_cycles <= 0:
@@ -68,6 +66,7 @@ class ClockScheduler:
     Keeps track of test cases' Clock objects, and implements polling mechanism to implement
     alternative trigger events at every input clock edge.
     """
+
     def __init__(self):
         self.clocks: list[ScheduledClock] = []
         self.poll_event = Event()
@@ -90,7 +89,9 @@ class ClockScheduler:
 
         for clk in self.clocks:
             if new_clock.signal == clk.signal:
-                raise RuntimeError(f"signal {clk.signal._name} already assigned a clock driver")
+                raise RuntimeError(
+                    f"signal {clk.signal._name} already assigned a clock driver"
+                )
 
         # add the clock to scheduler
         self.clocks.append(new_clock)
@@ -100,7 +101,11 @@ class ClockScheduler:
             self._scheduler_task = start_soon(self.run())
 
         # Log clock configuration
-        self.log.info("Driving Clock signal: '%s', Frequency: %.3f MHz", new_clock.signal._name, new_clock.frequency)
+        self.log.info(
+            "Driving Clock signal: '%s', Frequency: %.3f MHz",
+            new_clock.signal._name,
+            new_clock.frequency,
+        )
 
     def remove_clock(self, clock: ScheduledClock):
         self.clocks.remove(clock)
@@ -137,16 +142,20 @@ class ClockScheduler:
 
         # Find earliest time and collect all transitions at that time
         next_transition_time = min(t for t, _ in clk_transitions)
-        next_transitions = [item for t, item in clk_transitions if t == next_transition_time]
+        next_transitions = [
+            item for t, item in clk_transitions if t == next_transition_time
+        ]
 
         return next_transition_time, next_transitions
 
     async def run(self):
-        """ ClockScheduler main coroutine. """
+        """ClockScheduler main coroutine."""
         self.log.info("ClockScheduler started")
         while self.clocks:
             sim_time = get_sim_time()
-            next_transition_time, next_clock_transition_ops = self._get_clock_transitions(sim_time)
+            next_transition_time, next_clock_transition_ops = (
+                self._get_clock_transitions(sim_time)
+            )
 
             wait_time = next_transition_time - sim_time
             await Timer(wait_time, units="step")

--- a/src/cocotb_vivado/mock_triggers.py
+++ b/src/cocotb_vivado/mock_triggers.py
@@ -7,15 +7,17 @@ Since we cannot directly trigger on HDL clock events in Vivado, all triggers
 shared timer, providing consistent timing behavior across the simulation.
 """
 
-import cocotb
 import warnings
+
+import cocotb
 
 warnings.warn(
     "mock_triggers is deprecated and will be removed in a future release; "
     "use cocotb.clock.Clock() driver instead.",
     DeprecationWarning,
-    stacklevel=2
+    stacklevel=2,
 )
+
 
 class TimerSingleton:
     """Singleton class that provides a single reusable Timer(100, "ns") instance."""
@@ -25,7 +27,7 @@ class TimerSingleton:
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(TimerSingleton, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
 
     def set_timer(self, timer_set):
@@ -35,7 +37,9 @@ class TimerSingleton:
     def get_timer(self):
         """Get the timer instance, creating it if it doesn't exist."""
         if self._timer is None:
-            raise Exception("Timer not set. Use set_timer() to set a custom timer instance.")
+            raise Exception(
+                "Timer not set. Use set_timer() to set a custom timer instance."
+            )
         return self._timer
 
 
@@ -110,6 +114,7 @@ class OnSignal:
 cocotb.triggers.FallingEdge = OnFallingSignal
 cocotb.triggers.RisingEdge = OnRisingSignal
 cocotb.triggers.Edge = OnSignal
+
 
 async def clock(signal):
     signal.setimmediatevalue(0)

--- a/src/cocotb_vivado/runner.py
+++ b/src/cocotb_vivado/runner.py
@@ -1,0 +1,324 @@
+# Copyright cocotb-vivado contributors
+# Copyright 2026 Kiran Vuksanaj
+# Licensed under the Apache License 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from vicoco's Vivado runner (https://github.com/kiran-vuksanaj/vicoco),
+# restructured to delegate IP/BD/project handling to cocotb_vivado.vivado.
+
+"""Python runner subclass driving Vivado's XSim binaries.
+
+This module orchestrates XSim binary invocations only: ``xvlog``,
+``xvhdl``, and ``xelab``. The runner supports plain HDL sources;
+Vivado-managed sources (``.xci``, ``.bd``, ``.xpr``) are out of scope
+for this module.
+
+The contract for finding Vivado:
+
+* The XSim binaries must be on ``PATH`` (source ``settings64.sh``).
+* ``LD_LIBRARY_PATH`` must be set before the test subprocess runs.
+  If unset and ``XILINX_VIVADO`` is set, the runner synthesizes a
+  ``LD_LIBRARY_PATH`` from it as a courtesy fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from collections.abc import Mapping, Sequence
+from os import environ
+from pathlib import Path
+from typing import Literal, Union
+
+from cocotb import runner
+from cocotb.runner import VHDL, Simulator, Verilog
+
+PathLike = Union[Path, str]
+Command = list[str]
+Timescale = tuple
+
+WaveFormat = Literal["wdb", "vcd", "fst"]
+
+_FILE_DUMP_WAVES = """\
+{timescale_declaration}
+module cocotb_vivado_dump();
+  initial begin
+    $dumpfile("{waveform_filename}");
+    $dumpvars(0,{toplevel});
+  end
+endmodule
+"""
+
+
+class Vivado(Simulator):  # type: ignore[no-any-unimported]
+    """cocotb Python runner for the Vivado XSim simulator (XSI only)."""
+
+    supported_gpi_interfaces = {"verilog": ["xsi"], "vhdl": ["xsi"]}
+    LAUNCHING_MODULE = "cocotb_vivado"
+
+    def __init__(self) -> None:
+        self.extra_global_modules: list[str] = []
+        self.wave_format: WaveFormat | None = None
+        self.elab_modules: list[str] = []
+        self.xilinx_libraries: set = set()
+        self.snapshot_name: str = ""
+        self.wave_paths: dict = {}
+        self.log = logging.getLogger(__name__)
+        super().__init__()
+
+    def build(
+        self,
+        *args: object,
+        wave_format: WaveFormat | None = None,
+        extra_global_modules: Sequence[str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Build the HDL design with the XSim binaries.
+
+        Accepts every kwarg of :meth:`cocotb.runner.Simulator.build`,
+        plus:
+
+        Args:
+            wave_format: Waveform format to emit. ``None`` disables
+                waves. ``"fst"`` post-processes the VCD into FST via
+                ``vcd2fst`` (auto-downgrades to ``"vcd"`` with a
+                warning when ``vcd2fst`` is missing). Setting this
+                forces ``waves=True`` for the base build step.
+            extra_global_modules: Additional top-level global modules
+                to elaborate (e.g. user-supplied ``glbl`` shims).
+                Forwarded to ``xelab`` after the design top.
+        """
+        self.wave_format = self._resolve_wave_format(wave_format)
+        self.extra_global_modules = list(extra_global_modules or [])
+        if self.wave_format is not None:
+            kwargs.setdefault("waves", True)
+        super().build(*args, **kwargs)
+
+    def test(
+        self,
+        *args: object,
+        wave_format: WaveFormat | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Run the cocotb test. ``wave_format``: same semantics as in :meth:`build`."""
+        if wave_format is not None:
+            self.wave_format = self._resolve_wave_format(wave_format)
+            kwargs.setdefault("waves", True)
+        super().test(*args, **kwargs)
+        if not self.waves:
+            # XSI always writes a waveform DB on open (default name
+            # ``xsi.wdb``); with no waves requested it holds only the
+            # contentless design hierarchy. Drop it so build_dir keeps
+            # only real, traced captures — the ``<snapshot>.wdb`` a
+            # ``waves=True`` run produces.
+            (self.build_dir / "xsi.wdb").unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Simulator-binary contract
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _simulator_in_path() -> None:
+        """Verify XSim binaries are on ``PATH``."""
+        for exe in ("xelab", "xvlog", "xvhdl"):
+            if shutil.which(exe) is None:
+                raise SystemExit(
+                    f"ERROR: '{exe}' executable not found in PATH. "
+                    "Source your Vivado settings64.sh."
+                )
+
+    # ------------------------------------------------------------------
+    # Build / test command assembly
+    # ------------------------------------------------------------------
+
+    def _build_command(self) -> Sequence[Command]:
+        self._derive_snapshot_name()
+
+        verilog_build_args = [
+            str(arg) for arg in self.build_args if type(arg) in (str, Verilog)
+        ]
+        vhdl_build_args = [
+            str(arg) for arg in self.build_args if type(arg) in (str, VHDL)
+        ]
+        define_args = self._define_args()
+
+        if self.waves:
+            self._init_wave_paths()
+            if self.wave_format in ("vcd", "fst"):
+                self._write_wavedump_file()
+
+        cmds: list[Command] = []
+
+        for source in (Path(src) for src in self.sources):
+            if runner.is_verilog_source(source):
+                cmds.append(
+                    self._compile_cmd(source, "verilog")
+                    + define_args
+                    + verilog_build_args
+                )
+            elif runner.is_vhdl_source(source):
+                cmds.append(
+                    self._compile_cmd(source, "vhdl") + define_args + vhdl_build_args
+                )
+            else:
+                raise ValueError(
+                    f"Unknown file type: {source!s} cannot be compiled. "
+                    "IP / BD / XPR sources are not yet supported by this runner."
+                )
+
+        cmds.append(self._elab_command())
+        return cmds
+
+    def _test_command(self) -> Sequence[Command]:
+        if self.waves and self.hdl_toplevel_lang == "vhdl":
+            self.log.warning(
+                "Waveform dump via $dumpfile/$dumpvars is not reachable on a "
+                "VHDL top. Only the Vivado WDB output is available."
+            )
+
+        cmd: list[Command] = [["python3", "-m", self.LAUNCHING_MODULE]]
+
+        self._populate_test_env()
+
+        if self.waves and self.wave_format == "fst":
+            vcd_path = self.wave_paths.get("vcd")
+            fst_path = self.wave_paths.get("fst")
+            if vcd_path is not None and fst_path is not None:
+                cmd.append(["vcd2fst", str(vcd_path), str(fst_path)])
+
+        return cmd
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_wave_format(self, wave_format: WaveFormat | None) -> WaveFormat | None:
+        if wave_format is None:
+            return None
+        if wave_format == "fst" and shutil.which("vcd2fst") is None:
+            self.log.warning(
+                "wave_format='fst' requested but 'vcd2fst' is not on PATH "
+                "(install gtkwave). Falling back to wave_format='vcd'."
+            )
+            return "vcd"
+        return wave_format
+
+    def _derive_snapshot_name(self) -> None:
+        top = self.hdl_toplevel or "top"
+        self.snapshot_name = top.split(".")[-1]
+
+    def _init_wave_paths(self) -> None:
+        base = self.snapshot_name
+        self.wave_paths = {
+            "wdb": self.build_dir / f"{base}.wdb",
+            "vcd": self.build_dir / f"{base}.vcd",
+            "fst": self.build_dir / f"{base}.fst",
+        }
+
+    def _compile_cmd(self, src_file: Path, language: str) -> Command:
+        compiler = {"vhdl": "xvhdl", "verilog": "xvlog"}[language]
+        cmd: Command = [compiler, "--incr", "--relax", "-work", self.hdl_library]
+        if language == "verilog" and src_file.suffix == ".sv":
+            cmd.append("-sv")
+        cmd.append(str(src_file.resolve()))
+        if language == "verilog":
+            cmd += self._get_include_options(self.includes)
+        return cmd
+
+    def _elab_command(self) -> Command:
+        toplevel = self.hdl_toplevel or ""
+        if "." not in toplevel:
+            toplevel = f"{self.hdl_library}.{toplevel}"
+
+        elab_args: Command = [
+            "xelab",
+            "-top",
+            toplevel,
+            "-snapshot",
+            self.snapshot_name,
+            *self._get_include_options(self.includes),
+            *self._define_args(),
+            *self._get_parameter_options(self.parameters),
+        ]
+
+        elab_args.extend(self.elab_modules)
+        elab_args.extend(self.extra_global_modules)
+
+        for library_name in sorted(self.xilinx_libraries):
+            elab_args.extend(["-L", library_name])
+
+        elab_args.extend(["-dll", "-debug", "wave"])
+
+        return elab_args
+
+    def _define_args(self) -> Command:
+        out: Command = []
+        for key, val in self.defines.items():
+            out.extend(["-d", f"{key}={val}"])
+        return out
+
+    def _get_parameter_options(self, parameters: Mapping[str, object]) -> Command:
+        out: Command = []
+        for name, value in parameters.items():
+            out.extend(["-generic_top", f"{name}={value}"])
+        return out
+
+    @staticmethod
+    def _get_include_options(includes: Sequence[Path]) -> Command:
+        out: Command = []
+        for incl in includes:
+            out.extend(["-i", str(incl)])
+        return out
+
+    def _write_wavedump_file(self) -> None:
+        """Inject a Verilog module that calls ``$dumpfile``/``$dumpvars``."""
+        toplevel = self.snapshot_name
+        vcd_path = self.wave_paths["vcd"]
+        timescale_declaration = ""
+        if self.timescale is not None:
+            stepsize, precision = self.timescale
+            timescale_declaration = f"`timescale {stepsize} / {precision}"
+
+        text = _FILE_DUMP_WAVES.format(
+            waveform_filename=str(vcd_path),
+            toplevel=toplevel,
+            timescale_declaration=timescale_declaration,
+        )
+        dump_path = self.build_dir / "cocotb_vivado_dump.v"
+        dump_path.write_text(text, encoding="utf-8")
+
+        self.elab_modules.append(f"{self.hdl_library}.cocotb_vivado_dump")
+        self.sources.append(dump_path)
+
+    def _populate_test_env(self) -> None:
+        """Stage env vars the cocotb subprocess relies on."""
+        self.env["VIVADO_SNAPSHOT_NAME"] = self.snapshot_name
+        self.env["TOPLEVEL_LANG"] = self.hdl_toplevel_lang or "verilog"
+        if self.waves:
+            wdb = self.wave_paths.get("wdb")
+            if wdb is not None:
+                self.env["VIVADO_WDB_FILE"] = str(wdb)
+
+        if "LD_LIBRARY_PATH" not in os.environ:
+            xilinx_root = environ.get("XILINX_VIVADO")
+            if xilinx_root is None:
+                raise SystemExit(
+                    "ERROR: LD_LIBRARY_PATH is not set and XILINX_VIVADO is not "
+                    "set as a fallback. Source your Vivado settings64.sh so the "
+                    "XSI shared libraries can be loaded."
+                )
+            self.env["LD_LIBRARY_PATH"] = (
+                f"{xilinx_root}/lib/lnx64.o:{xilinx_root}/lib/lnx64.o/Default"
+            )
+
+
+def get_runner(simulator_name: str, **kwargs: object) -> Simulator:  # type: ignore[no-any-unimported]
+    """``get_runner`` shim that returns the Vivado runner for ``"vivado"``.
+
+    Delegates to :func:`cocotb.runner.get_runner` for any other name so
+    the same factory works for projects that mix simulators.
+    """
+    if simulator_name == "vivado":
+        return Vivado(**kwargs)
+    return runner.get_runner(simulator_name)

--- a/src/cocotb_vivado/stub/mgr.py
+++ b/src/cocotb_vivado/stub/mgr.py
@@ -4,7 +4,7 @@ MODULE = 0
 REG = 1
 
 
-class XsiPortHandle(object):
+class XsiPortHandle:
     def __init__(self, mgr, name, port_id, size):
         self.name = name
         self.port_id = port_id
@@ -47,7 +47,7 @@ class XsiPortHandle(object):
         return self.mgr.xsi.get_value(self.port_id)
 
 
-class XsimRootHandle(object):
+class XsimRootHandle:
     def __init__(self, mgr):
         self.mgr = mgr
 
@@ -81,7 +81,7 @@ class XsimRootHandle(object):
         return self.mgr.ports[name]
 
 
-class CbClosure(object):
+class CbClosure:
     def __init__(self, time_off, cb, ud):
         self.time_off = time_off
         self.cb = cb
@@ -96,16 +96,16 @@ class CbClosure(object):
         self.cb = None
 
 
-class Mgr(object):
+class Mgr:
     _inst = None
 
-    def __init__(self, xsim_design):
+    def __init__(self, xsim_design, wdb_file=None):
         self.xsim_design = xsim_design
 
         self.cb_d = {}
         self._stop_request = False
 
-        self.xsi = xsi.XSI(self.xsim_design)
+        self.xsi = xsi.XSI(self.xsim_design, wdb_file=wdb_file)
 
         self.ports = {}
         self.init_ports()
@@ -173,8 +173,8 @@ class Mgr(object):
         return cls._inst
 
     @classmethod
-    def init(cls, xsim_design):
-        cls._inst = Mgr(xsim_design)
+    def init(cls, xsim_design, wdb_file=None):
+        cls._inst = Mgr(xsim_design, wdb_file=wdb_file)
         return cls._inst
 
     # HACK / CHANGE !

--- a/src/cocotb_vivado/stub/simulator.py
+++ b/src/cocotb_vivado/stub/simulator.py
@@ -30,12 +30,14 @@ def register_timed_callback(t, cb, ud):
     try:
         return Mgr.inst().register_timed_callback(t, cb, ud)
     except Exception as e:
-        print("Exception while registering timed callback: %s" % str(e))
+        print(f"Exception while registering timed callback: {e!s}")
         traceback.print_exc()
 
 
 def register_value_change_callback(*args, **kwargs):
-    raise Exception("cocotb-xsim: Setting cocotb value-change callbacks is not supported")
+    raise Exception(
+        "cocotb-xsim: Setting cocotb value-change callbacks is not supported"
+    )
 
 
 def register_readonly_callback(*args, **kwargs):

--- a/src/cocotb_vivado/xsi.py
+++ b/src/cocotb_vivado/xsi.py
@@ -25,13 +25,16 @@ class XSI:
             ("bVal", ctypes.c_uint32),
         ]
 
-    def __init__(self, xsim_design, tracefile=None):
+    def __init__(self, xsim_design, tracefile=None, wdb_file=None):
         self.xsi_lib = ctypes.cdll.LoadLibrary(xsim_design)
         self.init_func_definitions()
 
-        self.xsi_handle = self.open(xsim_dir="")
+        if wdb_file is not None:
+            self.xsi_handle = self.open(xsim_dir="", wdb_file=wdb_file)
+        else:
+            self.xsi_handle = self.open(xsim_dir="")
 
-        if tracefile is not None:
+        if tracefile is not None or wdb_file is not None:
             self.xsi_lib.xsi_trace_all(self.xsi_handle)
 
     def init_func_definitions(self):

--- a/src/cocotb_vivado/xsi.py
+++ b/src/cocotb_vivado/xsi.py
@@ -1,5 +1,5 @@
 import ctypes
-from functools import lru_cache
+from functools import cache
 
 
 class XSI:
@@ -86,19 +86,23 @@ class XSI:
 
     def open(self, xsim_dir, wdb_file="xsi.wdb", log="xsi.log"):
         info = XSI.xsi_setup_info(
-            logFileName=log.encode("utf-8"), wdbFileName=wdb_file.encode("utf-8"), xsimDir=xsim_dir.encode("utf-8")
+            logFileName=log.encode("utf-8"),
+            wdbFileName=wdb_file.encode("utf-8"),
+            xsimDir=xsim_dir.encode("utf-8"),
         )
         return self.xsi_lib.xsi_open(ctypes.byref(info))
 
-    @lru_cache(maxsize=None)
+    @cache
     def get_port_name(self, port_id):
-        return self.xsi_lib.xsi_get_str_port(self.xsi_handle, port_id, XSI.xsiNameTopPort).decode("utf-8")
+        return self.xsi_lib.xsi_get_str_port(
+            self.xsi_handle, port_id, XSI.xsiNameTopPort
+        ).decode("utf-8")
 
     def put_value(self, port_id, value):
         vlog_val = self._binstr_to_vlog_logicval(value)
         self.xsi_lib.xsi_put_value(self.xsi_handle, port_id, vlog_val)
 
-    @lru_cache(maxsize=None)
+    @cache
     def _binstr_to_vlog_logicval(self, value):
         size = len(value)
         vlog_val = (XSI.s_xsi_vlog_logicval * ((size // 32) + 1))()
@@ -110,10 +114,10 @@ class XSI:
             # 0=00, 1=10, X=11, Z=01
             if v == "1":
                 vlog_val[si].aVal |= 0x1 << bi
-            elif v == "X" or v == "x":
+            elif v in {"X", "x"}:
                 vlog_val[si].aVal |= 0x1 << bi
                 vlog_val[si].bVal |= 0x1 << bi
-            elif v == "z" or v == "Z":
+            elif v in {"z", "Z"}:
                 vlog_val[si].bVal |= 0x1 << bi
 
             i += 1
@@ -139,11 +143,11 @@ class XSI:
             b_b = (vlog_val[si].bVal & (0x1 << bi)) > 0
 
             b_val = "0"
-            if b_a == True and b_b == False:
+            if b_a and not b_b:
                 b_val = "1"
-            elif b_a == True and b_b == True:
+            elif b_a and b_b:
                 b_val = "x"
-            elif b_a == False and b_b == True:
+            elif not b_a and b_b:
                 b_val = "z"
 
             value[size - 1 - i] = b_val
@@ -152,9 +156,11 @@ class XSI:
 
         return "".join(value)
 
-    @lru_cache(maxsize=None)
+    @cache
     def get_port_size(self, port_id):
-        return self.xsi_lib.xsi_get_int_port(self.xsi_handle, port_id, XSI.xsiHDLValueSize)
+        return self.xsi_lib.xsi_get_int_port(
+            self.xsi_handle, port_id, XSI.xsiHDLValueSize
+        )
 
     def get_precision(self):
         return self.xsi_lib.xsi_get_int(self.xsi_handle, XSI.xsiTimePrecisionKernel)
@@ -174,7 +180,9 @@ class XSI:
         return staus
 
     def get_port_number(self, name):
-        return self.xsi_lib.xsi_get_port_number(self.xsi_handle, ctypes.create_string_buffer(name.encode("utf-8")))
+        return self.xsi_lib.xsi_get_port_number(
+            self.xsi_handle, ctypes.create_string_buffer(name.encode("utf-8"))
+        )
 
     def get_error_info(self):
         return self.xsi_lib.xsi_close(self.xsi_handle)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+"""Shared pytest fixtures and test-session setup.
+
+TEMPORARY — remove the ``cocotb_vivado`` import below together with the
+legacy ``cocotb_vivado.run()`` path.
+
+Importing ``cocotb_vivado`` replaces ``cocotb.simulator`` with the
+in-process XSI stub, and cocotb caches the simulator handle at its own
+import time. ``test_simple_directlaunch`` simulates *in this process*,
+so the stub has to be installed before anything imports cocotb.
+
+pytest imports this file before any test module, which makes it the only
+place the ordering can be guaranteed for a whole-suite run: fixing the
+import order inside a single test module is not enough, because an
+earlier-collected module (``test_axil.py``) imports cocotb first.
+
+Runner-based tests are unaffected either way — they simulate in a
+``python -m cocotb_vivado`` subprocess that controls its own import order.
+"""
+
+import ctypes
+
+import pytest
+
+import cocotb_vivado  # noqa: F401
+
+
+def _xsi_kernel_loadable() -> bool:
+    """Can Vivado's XSI kernel library be dlopened in *this* process?
+
+    ``xsimk.so`` carries ``DT_NEEDED`` entries on Vivado's simulator-kernel
+    libraries, which the dynamic loader resolves through ``LD_LIBRARY_PATH``
+    *as captured when the process started*. Exporting it from inside Python
+    is useless, and preloading the kernel library by absolute path does not
+    help either -- it pulls its own transitive dependencies out of the same
+    directory. So this is an environment precondition a test cannot arrange
+    for itself, and Vivado's ``settings64.sh`` does not always export it.
+
+    Runner-based tests are unaffected: the runner exports LD_LIBRARY_PATH for
+    the ``python -m cocotb_vivado`` subprocess, deriving it from
+    ``XILINX_VIVADO`` when the shell has not set it.
+    """
+    for name in ("librdi_simulator_kernel.so", "libxv_simulator_kernel.so"):
+        try:
+            ctypes.CDLL(name)
+        except OSError:
+            continue
+        return True
+    return False
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip in-process XSI tests when the kernel library is not loadable."""
+    if _xsi_kernel_loadable():
+        return
+    skip = pytest.mark.skip(
+        reason=(
+            "Vivado's XSI kernel library is not on the dynamic loader path. "
+            "This test dlopens xsimk.so in the pytest process, so "
+            "LD_LIBRARY_PATH must be exported before Python starts: "
+            "export LD_LIBRARY_PATH=$XILINX_VIVADO/lib/lnx64.o"
+        )
+    )
+    for item in items:
+        if "in_process_xsi" in item.keywords:
+            item.add_marker(skip)

--- a/tests/fw.tcl
+++ b/tests/fw.tcl
@@ -1,5 +1,5 @@
 
-create_project -force fw fw -part xczu9eg-ffvb1156-2-e
+create_project -force fw fw -part xczu7eg-ffvc1156-2-e
 
 variable design_name
 set design_name fw

--- a/tests/tb_params.v
+++ b/tests/tb_params.v
@@ -1,0 +1,14 @@
+module tb_params #(
+    parameter WIDTH = 8,
+    parameter DEPTH = 4
+) (
+    input clk,
+    input [WIDTH-1:0] vec_in,
+    output [WIDTH-1:0] vec_out,
+    output [DEPTH-1:0] depth_out
+);
+
+    assign vec_out = vec_in;
+    assign depth_out = {DEPTH{clk}};
+
+endmodule

--- a/tests/test_axil.py
+++ b/tests/test_axil.py
@@ -1,14 +1,16 @@
-import cocotb_vivado
-import subprocess
 import os
 import pathlib
 import shutil
+import subprocess
 
 import cocotb
-from cocotb.triggers import Timer
+import pytest
 from cocotb.clock import Clock
-
+from cocotb.triggers import Timer
 from cocotbext.axi import AxiLiteBus, AxiLiteMaster, AxiLiteRam
+
+import cocotb_vivado
+import cocotb_vivado.mock_triggers
 
 
 @cocotb.test()
@@ -22,7 +24,7 @@ async def cocotb_axil_test(dut):
     dut.rst.value = 0
 
     axil_master = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "axil"), dut.clk, dut.rst)
-    axil_ram = AxiLiteRam(AxiLiteBus.from_prefix(dut, "axil"), dut.clk, dut.rst, size=2**16)
+    AxiLiteRam(AxiLiteBus.from_prefix(dut, "axil"), dut.clk, dut.rst, size=2**16)
 
     data_in = list(range(16))
 
@@ -37,6 +39,7 @@ async def cocotb_axil_test(dut):
     assert data_in == data_out
 
 
+@pytest.mark.in_process_xsi
 def test_axil():
     src_path = pathlib.Path(__file__).parent.absolute()
 
@@ -46,7 +49,11 @@ def test_axil():
         subprocess.run(["xvlog", src_path / "test_axil.v"])
         subprocess.run(["xelab", "work.test_axil", "-dll"])
 
-    cocotb_vivado.run(module="test_axil", xsim_design="xsim.dir/work.test_axil/xsimk.so", top_level_lang="verilog")
+    cocotb_vivado.run(
+        module="test_axil",
+        xsim_design="xsim.dir/work.test_axil/xsimk.so",
+        top_level_lang="verilog",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_fw.py
+++ b/tests/test_fw.py
@@ -1,15 +1,29 @@
-from cocotb_vivado import run
-import subprocess
 import os
 import pathlib
 import shutil
+import subprocess
 
 import cocotb
-from cocotb.triggers import Timer
+import pytest
 from cocotb.clock import Clock
+from cocotb.triggers import Timer
+from cocotbext.axi import (
+    AxiLiteBus,
+    AxiLiteMaster,
+    AxiStreamBus,
+    AxiStreamSink,
+    AxiStreamSource,
+)
 
-from cocotbext.axi import AxiLiteBus, AxiLiteMaster
-from cocotbext.axi import AxiStreamSink, AxiStreamSource, AxiStreamBus
+from cocotb_vivado import run
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("COCOTB_VIVADO_TEST_DIRECT"),
+    reason=(
+        "Legacy cocotb_vivado.run()-based test with IP/BD dependencies. "
+        "Set COCOTB_VIVADO_TEST_DIRECT=1 to run."
+    ),
+)
 
 
 async def reset(signal, timer):
@@ -27,9 +41,15 @@ async def cocotb_fw_test(dut):
 
     cocotb.start_soon(reset(dut.areset, Timer(520, "ns")))
 
-    axil_master = AxiLiteMaster(AxiLiteBus.from_prefix(dut, "S_AXI"), dut.aclk, dut.areset)
-    axis_rx = AxiStreamSource(AxiStreamBus.from_prefix(dut, "AXIS_RX"), dut.aclk, dut.areset)
-    axis_tx = AxiStreamSink(AxiStreamBus.from_prefix(dut, "AXIS_TX"), dut.aclk, dut.areset)
+    axil_master = AxiLiteMaster(
+        AxiLiteBus.from_prefix(dut, "S_AXI"), dut.aclk, dut.areset
+    )
+    axis_rx = AxiStreamSource(
+        AxiStreamBus.from_prefix(dut, "AXIS_RX"), dut.aclk, dut.areset
+    )
+    axis_tx = AxiStreamSink(
+        AxiStreamBus.from_prefix(dut, "AXIS_TX"), dut.aclk, dut.areset
+    )
 
     data_in = list(range(32))
     await axil_master.write(0x10, data_in)
@@ -39,8 +59,6 @@ async def cocotb_fw_test(dut):
     print(data_out)
 
     assert data_in == data_out
-
-    #
 
     rx_data_send = []
     for i in range(4):
@@ -59,10 +77,10 @@ async def cocotb_fw_test(dut):
 
     assert rx_data == rx_data_send
 
-    #
-
     for i in range(8):
-        await axil_master.write(AXIS_FIFO_BASEADDR + 0x10, list(range(i * 4, i * 4 + 4)))
+        await axil_master.write(
+            AXIS_FIFO_BASEADDR + 0x10, list(range(i * 4, i * 4 + 4))
+        )
         await axil_master.wait()
 
     await axil_master.write(AXIS_FIFO_BASEADDR + 0x14, [0x20, 0, 0, 0])
@@ -75,12 +93,15 @@ async def cocotb_fw_test(dut):
 
     dut.areset.value = 0
 
+
 def test_fw():
     src_path = pathlib.Path(__file__).parent.absolute()
 
     shutil.rmtree("fw", ignore_errors=True)
     if not os.path.exists("fw/fw.xpr"):
-        subprocess.run(["vivado", "-nolog", "-mode", "tcl", "-source", src_path / "fw.tcl"])
+        subprocess.run(
+            ["vivado", "-nolog", "-mode", "tcl", "-source", src_path / "fw.tcl"]
+        )
 
     shutil.rmtree("xsim.dir", ignore_errors=True)
     if not os.path.exists("xsim.dir/fw_wrapper/xsimk.so"):
@@ -88,8 +109,11 @@ def test_fw():
         subprocess.run(["xvhdl", "-prj", f"{src_path}/fw/sim_export/xsim/vhdl.prj"])
         subprocess.run(["./fw/sim_export/xsim/fw_wrapper.sh", "-step", "elaborate"])
 
-    run(module="test_fw", xsim_design="xsim.dir/fw_wrapper/xsimk.so", top_level_lang="verilog")
-
+    run(
+        module="test_fw",
+        xsim_design="xsim.dir/fw_wrapper/xsimk.so",
+        top_level_lang="verilog",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,77 @@
+"""Verify ``runner.build(parameters=...)`` forwards values to xelab via ``-generic_top``.
+
+Also probes the error path: an unknown parameter name should make xelab
+fail with ``[XSIM 43-3281]``, which the runner surfaces as
+``SystemExit``.
+"""
+
+import os
+from pathlib import Path
+
+import cocotb
+import pytest
+from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
+
+
+@cocotb.test()
+async def cocotb_param_test(dut):
+    expected_width = int(os.environ["EXPECTED_WIDTH"])
+    expected_depth = int(os.environ["EXPECTED_DEPTH"])
+
+    await Timer(1, "ns")
+
+    assert len(dut.vec_out) == expected_width, (
+        f"expected vec_out width {expected_width}, got {len(dut.vec_out)}"
+    )
+    assert len(dut.depth_out) == expected_depth, (
+        f"expected depth_out width {expected_depth}, got {len(dut.depth_out)}"
+    )
+
+
+def _run(parameters):
+    proj_path = Path(__file__).resolve().parent
+    sources = [proj_path / "tb_params.v"]
+
+    sim = os.getenv("SIM", "vivado")
+    runner = get_runner(sim)
+
+    runner.build(
+        sources=sources,
+        hdl_toplevel="tb_params",
+        always=True,
+        timescale=("1ns", "1ps"),
+        parameters=parameters,
+    )
+    runner.test(
+        hdl_toplevel="tb_params",
+        test_module="test_params",
+        hdl_toplevel_lang="verilog",
+        testcase="cocotb_param_test",
+    )
+
+
+def test_params_default():
+    os.environ["EXPECTED_WIDTH"] = "8"
+    os.environ["EXPECTED_DEPTH"] = "4"
+    _run(parameters={})
+
+
+def test_params_override():
+    os.environ["EXPECTED_WIDTH"] = "16"
+    os.environ["EXPECTED_DEPTH"] = "7"
+    _run(parameters={"WIDTH": 16, "DEPTH": 7})
+
+
+def test_params_unknown():
+    os.environ["EXPECTED_WIDTH"] = "8"
+    os.environ["EXPECTED_DEPTH"] = "4"
+    with pytest.raises(SystemExit):
+        _run(parameters={"NOT_A_REAL_PARAM": 1234})
+
+
+if __name__ == "__main__":
+    test_params_default()
+    test_params_override()
+    test_params_unknown()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,11 +1,13 @@
-import subprocess
-import os
-import pathlib
-import shutil
+"""Smoke test for the cocotb-vivado Python runner."""
 
-import cocotb_vivado
+import os
+from pathlib import Path
+
 import cocotb
+import pytest
 from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
 
 
 @cocotb.test()
@@ -19,15 +21,45 @@ async def simple_test(dut):
 
 
 def test_simple():
-    src_path = pathlib.Path(__file__).parent.absolute()
+    """Build tb.v with the Python runner and run the cocotb test."""
+    proj_path = Path(__file__).resolve().parent
+    sources = [proj_path / "tb.v"]
 
+    sim = os.getenv("SIM", "vivado")
+    runner = get_runner(sim)
+
+    runner.build(
+        sources=sources,
+        hdl_toplevel="tb",
+        always=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="tb",
+        test_module="test_simple",
+        hdl_toplevel_lang="verilog",
+        testcase="simple_test",
+    )
+
+
+@pytest.mark.in_process_xsi
+def test_simple_directlaunch():
+    """Legacy ``cocotb_vivado.run()`` path, kept for regression coverage."""
+    import shutil  # noqa: PLC0415
+    import subprocess  # noqa: PLC0415
+
+    import cocotb_vivado  # noqa: PLC0415
+
+    src_path = Path(__file__).resolve().parent
     shutil.rmtree("xsim.dir", ignore_errors=True)
+    subprocess.run(["xvlog", str(src_path / "tb.v")], check=True)
+    subprocess.run(["xelab", "work.tb", "-dll"], check=True)
 
-    if not os.path.exists("xsim.dir/work.tb/xsimk.so"):
-        subprocess.run(["xvlog", src_path / "tb.v"])
-        subprocess.run(["xelab", "work.tb", "-dll"])
-
-    cocotb_vivado.run(module="test_simple", xsim_design="xsim.dir/work.tb/xsimk.so", top_level_lang="verilog")
+    cocotb_vivado.run(
+        module="test_simple",
+        xsim_design="xsim.dir/work.tb/xsimk.so",
+        top_level_lang="verilog",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -1,15 +1,15 @@
-from cocotb_vivado import run
-import subprocess
+"""Clock + vector-pin behavioral test, exercising the Python runner."""
+
 import os
-import pathlib
-import shutil
+from pathlib import Path
 
 import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import Edge, Timer
-from cocotb.binary import BinaryValue
-
 import pytest
+from cocotb.binary import BinaryValue
+from cocotb.clock import Clock
+from cocotb.triggers import Timer
+
+from cocotb_vivado.runner import get_runner
 
 
 async def on_signal(signal, timer):
@@ -48,36 +48,42 @@ async def cocotb_tb_test(dut):
 @cocotb.test()
 async def cocotb_tb_test_fail(dut):
     await Timer(10, "ns")
-    assert 1 == 0
+    pytest.fail("deliberate failure to exercise the xfail path")
 
 
-def run_tb(module="test_tb"):
-    src_path = pathlib.Path(__file__).parent.absolute()
+def _run_tb(test_module="test_tb", testcase="cocotb_tb_test"):
+    proj_path = Path(__file__).resolve().parent
+    sources = [proj_path / "tb.v"]
 
-    shutil.rmtree("xsim.dir", ignore_errors=True)
+    sim = os.getenv("SIM", "vivado")
+    runner = get_runner(sim)
 
-    if not os.path.exists("xsim.dir/work.tb/xsimk.so"):
-        subprocess.run(["xvlog", src_path / "tb.v"])
-        subprocess.run(["xelab", "work.tb", "-dll"])
-
-    run(module=module, xsim_design="xsim.dir/work.tb/xsimk.so", top_level_lang="verilog")
+    runner.build(
+        sources=sources,
+        hdl_toplevel="tb",
+        always=True,
+        timescale=("1ns", "1ps"),
+    )
+    runner.test(
+        hdl_toplevel="tb",
+        test_module=test_module,
+        hdl_toplevel_lang="verilog",
+        testcase=testcase,
+    )
 
 
 def test_tb():
-    os.environ["TESTCASE"] = "cocotb_tb_test"
-    run_tb()
+    _run_tb(testcase="cocotb_tb_test")
 
 
 @pytest.mark.xfail
 def test_tb_fail():
-    os.environ["TESTCASE"] = "cocotb_tb_test_fail"
-    run_tb()
+    _run_tb(testcase="cocotb_tb_test_fail")
 
 
 @pytest.mark.xfail
 def test_tb_fail_init():
-    os.environ["TESTCASE"] = "cocotb_tb_test"
-    run_tb(module="no_exisitng")
+    _run_tb(test_module="no_existing")
 
 
 if __name__ == "__main__":

--- a/tests/test_xsi.py
+++ b/tests/test_xsi.py
@@ -1,9 +1,14 @@
-import subprocess
 import os
 import pathlib
-from cocotb_vivado import xsi
 import random
 import shutil
+import subprocess
+
+import pytest
+
+from cocotb_vivado import xsi
+
+pytestmark = pytest.mark.in_process_xsi
 
 
 def test_xsi():


### PR DESCRIPTION
Adds a cocotb-style Python runner for the Vivado simulator (XSim), reachable via
`get_runner("vivado")` with the standard `build()` / `test()` API. The runner drives
the XSim binaries directly (`xelab` / `xvlog` / `xvhdl`) and runs cocotb through the
in-process XSI stub.

Builds on and extends @kiran-vuksanaj's #8 ("Python runner") — same core approach,
fleshed out with packaging, docs, examples, and CI (credited via `Co-authored-by`).

### What's in it
- **Runner** (`cocotb_vivado.runner`): `get_runner("vivado")` → `build()`/`test()`;
  snapshot derived from `hdl_toplevel`; `wave_format=` selects `wdb`/`vcd`/`fst`
  (auto-downgrades `fst`→`vcd` if `vcd2fst` is absent); parameter/generic pass-through.
- **Packaging & CI**: PEP 621 `pyproject.toml`, ruff + mypy config, a GitHub Actions
  lint workflow, pre-commit hooks, and git-tag-based versioning (setuptools-scm —
  tag `vX.Y.Z` to release).
- **Docs**: README rewritten around the runner-first flow; CONTRIBUTING / CHANGELOG /
  MIGRATION; PR template.
- **Examples**: a minimal counter and a parameterized design under `examples/`.
- **Tests**: `tests/` migrated onto the runner; the legacy direct-launch path stays
  available behind a skip gate.

### Scope / constraints
- Linux only (XSI loaded via ctypes); cocotb `>=1.8,<2.0`; tested on Vivado 2023.1 and 2025.1.
- Needs the XSim binaries on `PATH` and `LD_LIBRARY_PATH` set (or `XILINX_VIVADO` as a fallback).

### Testing
- `ruff` + `mypy` clean (matches CI).
- Local sims (cocotb 1.9.2), `pytest tests/ examples/`:
  - Vivado 2023.1 → 13 passed, 1 skipped, 2 xfailed
  - Vivado 2025.1 → 13 passed, 1 skipped, 2 xfailed

  (the 1 skip is the legacy `run()`-based `test_fw`, gated behind `COCOTB_VIVADO_TEST_DIRECT`.)
