### PR TITLE
ci: pin ruff/mypy and add tag-driven release workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,10 @@ jobs:
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          # Pin the linters: an unpinned ``pip install ruff`` tracks the
+          # latest release, which promotes new rules and breaks CI on a
+          # tree that was clean the day before. Bump these deliberately.
+          pip install ruff==0.15.15 mypy==2.1.0
           pip install -e .
 
       - name: Ruff check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history + tags so setuptools-scm can derive the version
+          # from the pushed tag (a shallow clone yields 0.0.0).
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes
+
+  pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    # Opt-in. Enable by setting repository variable PUBLISH_TO_PYPI=true
+    # and configuring PyPI trusted publishing for this repo/workflow
+    # (https://docs.pypi.org/trusted-publishers/). Until then this job
+    # is skipped, so tagging still produces a GitHub Release.
+    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is a follow-up to #9.

## Why

`lint` went red on `main` the first time it ran on the default branch (right after #9 merged). Cause is **unpinned linters**: `pip install ruff` pulls the latest release, and ruff 0.16 promoted a batch of rules (`TRY002`, `B019`, `FA102`, …) that fire on a tree that was clean under 0.15.15. Nothing in the code changed — the tool did.

## What

1. **Pin the linters** (`ruff==0.15.15`, `mypy==2.1.0`) so CI is reproducible. Verified clean on the current `main` tree. Bump deliberately going forward.
2. **Add `release.yml`** — pushing a `v[0-9]*` tag:
   - builds sdist + wheel (setuptools-scm derives the version from the tag: `v0.0.6` → `0.0.6`);
   - creates a GitHub Release with the artifacts attached and auto-generated notes.
   - An **opt-in** `pypi` job publishes via trusted publishing; it is skipped unless repo variable `PUBLISH_TO_PYPI=true` is set and a PyPI trusted publisher is configured, so tagging is safe today and always produces a GitHub Release.

This also fills the gap behind "there's no make-release automation" — the repo only had `lint.yml`; a tag now drives the release.

## Test

- `ruff==0.15.15` check + format: clean on `main`.
- `python -m build`: produces sdist + wheel; version resolves from `v0.0.5` → `0.0.6.devN` (a real `v0.0.6` tag → `0.0.6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)