### PR TITLE
ci: bump actions to Node-24 majors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history + tags so setuptools-scm can derive the version
           # from the pushed tag (a shallow clone yields 0.0.0).
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -28,7 +28,7 @@ jobs:
           python -m build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/*
@@ -54,7 +54,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist


### PR DESCRIPTION
GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). `actions/checkout@v4` and `actions/setup-python@v5` target Node 20, so runs are force-migrated to Node 24 with a deprecation warning (and will hard-fail once Node 20 is removed).

Bump each action to its **first Node-24 major** — pure runtime bumps, no input/behavior changes for our usage:

| action | was | now |
|--------|-----|-----|
| actions/checkout | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v6 |
| actions/download-artifact | v4 | v7 |

(`pypa/gh-action-pypi-publish` is a Docker action — unaffected.)

Follows #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)