### PR TITLE
Tier-1 build cache: skip recompilation when nothing changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runner.build()` / `runner.test()` interface. Pure XSim binary
   orchestration: only `xelab` / `xvlog` / `xvhdl` are invoked
   directly.
+- Content-hash build cache at `build_dir/build_signature.json`
+  (active by default; `always=True` bypasses it). The signature
+  captures user HDL source content hashes, every kwarg that affects
+  output (parameters, defines, build_args, includes, timescale,
+  waves, wave_format, extra_global_modules, hdl_toplevel,
+  hdl_library), each `VivadoSource.fingerprint()`, and
+  `xelab` / `xvlog` / `xvhdl --version`. On a hit, the entire
+  pipeline — including `VivadoSource.prepare()` — is skipped.
+  On a miss, `prepare()` is called with `force=True` so each
+  source bypasses its own mtime check (guards against
+  content-change-without-mtime-change, e.g. after `git checkout`).
+  Cache decisions are logged on the `cocotb_vivado.runner.cache`
+  logger.
 - `cocotb_vivado.vivado` — sub-package for Vivado-managed sources
   and the tool-driver helpers behind them. Architectural rule:
   anything that runs `vivado -mode batch` lives here, not in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,23 @@ Every other test runs unconditionally -- there are no opt-in gates, so a
 green `pytest tests/` means the whole suite really ran. Note `pytest
 tests/` does not cover `examples/`; run both.
 
+**Clearing the build cache after runner-code edits.** Tests default to
+`always=False`, so the Tier 1 build cache
+(`tests/sim_build/build_signature.json`) is active. The signature keys
+on build *inputs* (sources, kwargs, fingerprints, tool versions) — not
+on `runner.py` itself. After editing `src/cocotb_vivado/runner.py` or
+any pipeline-affecting module (`vivado/sources.py`, `vivado/_tcl.py`,
+…), clear `tests/sim_build/` before re-running:
+
+```bash
+rm -rf tests/sim_build && pytest tests/test_simple.py
+```
+
+Otherwise the cache hits on the stale snapshot, the modified code path
+skips xvlog/xvhdl/xelab, and the test passes against pre-edit
+artifacts. If you only changed tests or docs, the cache invalidates
+correctly on its own.
+
 ## Linting and type checking
 
 ```bash

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -145,6 +145,25 @@ sources flow through `xvlog` / `xvhdl` directly. Pure-RTL builds
 without any `VivadoSource` instance never touch the `vivado` binary
 — `xelab` / `xvlog` / `xvhdl` are the only external programs invoked.
 
+## Build cache
+
+`runner.build(always=False)` consults a content-hash signature at
+`build_dir/build_signature.json`. A hit (every input byte-identical
+to a prior successful build, snapshot artifacts still on disk) skips
+the entire compile/elab pipeline including any `VivadoSource.prepare()`
+calls. Pass `always=True` to force a rebuild regardless. The cache is
+correct under `git checkout` content-vs-mtime divergence — the runner
+re-runs `VivadoSource.prepare(force=True)` on any miss, bypassing each
+source's own mtime check.
+
+Decisions are visible via the `cocotb_vivado.runner.cache` logger
+(INFO-level — one line per decision: `cache hit` or
+`cache miss: <reason>`). To see them in pytest:
+
+```
+pytest -o log_cli=true -o log_cli_level=INFO test_simple.py
+```
+
 ## Environment
 
 Before running tests:

--- a/examples/counter/test_counter.py
+++ b/examples/counter/test_counter.py
@@ -35,18 +35,21 @@ async def counter_increments(dut):
 
 def test_counter():
     here = Path(__file__).resolve().parent
+    build_dir = here / "sim_build"
     runner = get_runner(os.getenv("SIM", "vivado"))
     runner.build(
         sources=[here / "counter.v"],
         hdl_toplevel="counter",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="counter",
         test_module="test_counter",
         hdl_toplevel_lang="verilog",
         testcase="counter_increments",
+        build_dir=str(build_dir),
     )
 
 

--- a/examples/parameters/test_parameters.py
+++ b/examples/parameters/test_parameters.py
@@ -27,19 +27,22 @@ async def check_width(dut):
 def _run(width):
     os.environ["EXPECTED_WIDTH"] = str(width)
     here = Path(__file__).resolve().parent
+    build_dir = here / "sim_build"
     runner = get_runner(os.getenv("SIM", "vivado"))
     runner.build(
         sources=[here / "params_dut.v"],
         hdl_toplevel="params_dut",
-        always=True,
+        always=False,
         parameters={"WIDTH": width},
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="params_dut",
         test_module="test_parameters",
         hdl_toplevel_lang="verilog",
         testcase="check_width",
+        build_dir=str(build_dir),
     )
 
 

--- a/src/cocotb_vivado/runner.py
+++ b/src/cocotb_vivado/runner.py
@@ -25,9 +25,13 @@ The contract for finding Vivado:
 
 from __future__ import annotations
 
+import functools
+import hashlib
+import json
 import logging
 import os
 import shutil
+import subprocess
 from collections.abc import Mapping, Sequence
 from os import environ
 from pathlib import Path
@@ -44,6 +48,11 @@ Timescale = tuple
 
 WaveFormat = Literal["wdb", "vcd", "fst"]
 
+SIGNATURE_SCHEMA_VERSION = 1
+SIGNATURE_FILENAME = "build_signature.json"
+
+cache_log = logging.getLogger("cocotb_vivado.runner.cache")
+
 _FILE_DUMP_WAVES = """\
 {timescale_declaration}
 module cocotb_vivado_dump();
@@ -53,6 +62,54 @@ module cocotb_vivado_dump();
   end
 endmodule
 """
+
+
+def _hash_file(path: Path) -> str:
+    """SHA-256 hex digest of file contents. Empty string if missing."""
+    if not path.exists() or not path.is_file():
+        return ""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@functools.cache
+def get_xsim_tool_versions() -> dict[str, str]:
+    """Capture xelab/xvlog/xvhdl --version output, cached for the session."""
+    versions: dict[str, str] = {}
+    for tool in ("xelab", "xvlog", "xvhdl"):
+        try:
+            result = subprocess.run(
+                [tool, "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            lines = result.stdout.strip().splitlines()
+            versions[tool] = lines[0] if lines else ""
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            versions[tool] = ""
+    return versions
+
+
+def _load_signature(sig_path: Path) -> dict | None:
+    """Read and parse a stored build_signature.json, or None if absent/corrupt."""
+    if not sig_path.exists():
+        return None
+    try:
+        return json.loads(sig_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _save_signature(sig_path: Path, sig: dict) -> None:
+    """Write a signature dict as JSON. Atomic via tmp-and-rename."""
+    tmp = sig_path.with_suffix(sig_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(sig, sort_keys=True, indent=2), encoding="utf-8")
+    tmp.replace(sig_path)
 
 
 class Vivado(Simulator):  # type: ignore[no-any-unimported]
@@ -69,6 +126,8 @@ class Vivado(Simulator):  # type: ignore[no-any-unimported]
         self.snapshot_name: str = ""
         self.wave_paths: dict = {}
         self.vivado_sources: list[VivadoSource] = []
+        self._pending_signature: dict | None = None
+        self._force_prepare: bool = False
         self.log = logging.getLogger(__name__)
         super().__init__()
 
@@ -124,7 +183,18 @@ class Vivado(Simulator):  # type: ignore[no-any-unimported]
         self.vivado_sources = [s for s in sources_in if isinstance(s, VivadoSource)]
         kwargs["sources"] = [s for s in sources_in if not isinstance(s, VivadoSource)]
 
+        self._pending_signature = None
+        self._force_prepare = False
+
         super().build(*args, **kwargs)
+
+        # Build succeeded (no exception). Persist the new signature on a
+        # cache miss. On a hit, _pending_signature stays None — the
+        # already-on-disk signature is still authoritative.
+        if self._pending_signature is not None:
+            _save_signature(
+                self.build_dir / SIGNATURE_FILENAME, self._pending_signature
+            )
 
     def test(
         self,
@@ -179,6 +249,19 @@ class Vivado(Simulator):  # type: ignore[no-any-unimported]
             if self.wave_format in ("vcd", "fst"):
                 self._write_wavedump_file()
 
+        # Tier 1 cache probe: skip the whole pipeline when the input
+        # signature matches a prior successful build and its snapshot
+        # artifacts are still on disk.
+        current_signature = self._compute_signature()
+        if not self.always and self._cache_hit(current_signature):
+            cache_log.info("cache hit: skipping prepare + xvlog/xvhdl/xelab")
+            return []
+        self._pending_signature = current_signature
+        # Tier 1 missed (or always=True). Force each VivadoSource to
+        # re-run its Vivado batch even if its mtime check would have
+        # skipped — guards against content-change-without-mtime-change.
+        self._force_prepare = True
+
         cmds: list[Command] = []
 
         # Vivado-managed sources first: their .prepare() may run vivado batch
@@ -215,7 +298,9 @@ class Vivado(Simulator):  # type: ignore[no-any-unimported]
         Side effects: extends ``self.xilinx_libraries`` and
         ``self.elab_modules`` from the returned :class:`SimDirInfo`.
         """
-        info = source.prepare(self.build_dir, self.hdl_library)
+        info = source.prepare(
+            self.build_dir, self.hdl_library, force=self._force_prepare
+        )
         self.xilinx_libraries.update(info.libraries)
         self.elab_modules.extend(info.glbl_modules)
         cmds: list[Command] = []
@@ -243,6 +328,57 @@ class Vivado(Simulator):  # type: ignore[no-any-unimported]
                 cmd.append(["vcd2fst", str(vcd_path), str(fst_path)])
 
         return cmd
+
+    # ------------------------------------------------------------------
+    # Tier 1 build cache
+    # ------------------------------------------------------------------
+
+    def _compute_signature(self) -> dict:
+        """Build the JSON-serializable signature for the current build."""
+        return {
+            "schema_version": SIGNATURE_SCHEMA_VERSION,
+            "tool_versions": get_xsim_tool_versions(),
+            "kwargs": {
+                "hdl_toplevel": self.hdl_toplevel,
+                "hdl_library": self.hdl_library,
+                "parameters": dict(sorted(self.parameters.items())),
+                "defines": dict(sorted(self.defines.items())),
+                "build_args": [str(a) for a in self.build_args],
+                "includes": [
+                    {"path": str(p), "sha256": _hash_file(Path(p))}
+                    for p in self.includes
+                ],
+                "timescale": list(self.timescale) if self.timescale else None,
+                "waves": bool(self.waves),
+                "wave_format": self.wave_format,
+                "extra_global_modules": list(self.extra_global_modules),
+            },
+            "user_sources": [
+                {"path": str(p), "sha256": _hash_file(Path(p))} for p in self.sources
+            ],
+            "vivado_sources": [s.fingerprint() for s in self.vivado_sources],
+        }
+
+    def _cache_hit(self, current: dict) -> bool:
+        """Return True iff a valid cache exists and all artifacts are present."""
+        sig_path = self.build_dir / SIGNATURE_FILENAME
+        stored = _load_signature(sig_path)
+        if stored is None:
+            cache_log.info("cache miss: signature absent or unreadable")
+            return False
+        if stored != current:
+            cache_log.info("cache miss: signature mismatch")
+            return False
+        snapshot = self.build_dir / "xsim.dir" / self.snapshot_name / "xsimk.so"
+        if not snapshot.exists():
+            cache_log.info("cache miss: snapshot artifact missing (%s)", snapshot)
+            return False
+        if self.waves and self.wave_format in ("vcd", "fst"):
+            dump_file = self.build_dir / "cocotb_vivado_dump.v"
+            if not dump_file.exists():
+                cache_log.info("cache miss: wavedump file missing")
+                return False
+        return True
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/cocotb_vivado/vivado/sources.py
+++ b/src/cocotb_vivado/vivado/sources.py
@@ -23,6 +23,7 @@ format:
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -37,18 +38,60 @@ from .sim_dir import SimDirInfo, read_sim_dir
 PathLike = Union[Path, str]
 
 
+def _hash_file(path: Path) -> str:
+    """SHA-256 hex digest of file contents. Empty string if missing."""
+    if not path.exists() or not path.is_file():
+        return ""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _hash_dir(root: Path) -> str:
+    """SHA-256 of a sorted ``(relpath, sha256)`` manifest under ``root``."""
+    if not root.is_dir():
+        return ""
+    items: list = []
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            items.append(f"{p.relative_to(root)}\0{_hash_file(p)}")
+    return hashlib.sha256("\n".join(items).encode("utf-8")).hexdigest()
+
+
 class VivadoSource(ABC):
     """Abstract Vivado-managed source for :meth:`Vivado.build`.
 
     Subclasses know how to produce a Vivado simulation-scripts
     directory (with ``*.prj`` files and a sibling xelab ``*.sh``
     script) and return a :class:`SimDirInfo` view of it. Caching
-    via mtime checks is the subclass's responsibility.
+    via mtime checks is the subclass's responsibility; the runner's
+    Tier 1 cache consults :meth:`fingerprint` to detect input
+    changes that mtime can't see (content-vs-mtime divergence).
     """
 
     @abstractmethod
-    def prepare(self, build_dir: Path, hdl_library: str) -> SimDirInfo:
-        """(Re)generate the simulation scripts and return their distilled view."""
+    def prepare(
+        self, build_dir: Path, hdl_library: str, force: bool = False
+    ) -> SimDirInfo:
+        """(Re)generate the simulation scripts and return their distilled view.
+
+        ``force=True`` bypasses the subclass's mtime check, used by the
+        runner on a Tier 1 cache miss to ensure Vivado re-runs even
+        when the inputs' content changed without their mtimes changing
+        (e.g., post ``git checkout``).
+        """
+
+    @abstractmethod
+    def fingerprint(self) -> dict:
+        """JSON-serializable identity for the runner's Tier 1 cache signature.
+
+        Captures the source's *inputs* (constructor kwargs + content
+        hashes of file inputs) — not its derived outputs. When
+        ``builder_tcl`` is set, the TCL is the canonical input; the
+        artifacts it produces are derived and not hashed here.
+        """
 
 
 class VivadoIp(VivadoSource):
@@ -100,7 +143,33 @@ class VivadoIp(VivadoSource):
         )
         self._part_num = part_num
 
-    def prepare(self, build_dir: Path, hdl_library: str) -> SimDirInfo:
+    def fingerprint(self) -> dict:
+        # builder_tcl, when set, is the canonical input; the XCIs it
+        # produces are derived. Hash the TCL only; treat XCI paths as
+        # identifiers (path strings). Without builder_tcl, the XCIs
+        # are the canonical inputs and must be hashed.
+        paths_field: object
+        if self.builder_tcl is not None:
+            paths_field = [str(p) for p in self.paths]
+            builder = {
+                "path": str(self.builder_tcl),
+                "sha256": _hash_file(self.builder_tcl),
+            }
+        else:
+            paths_field = [
+                {"path": str(p), "sha256": _hash_file(p)} for p in self.paths
+            ]
+            builder = None
+        return {
+            "kind": "VivadoIp",
+            "paths": paths_field,
+            "builder_tcl": builder,
+            "part_num": _resolve_part_num(self._part_num) or "",
+        }
+
+    def prepare(
+        self, build_dir: Path, hdl_library: str, force: bool = False
+    ) -> SimDirInfo:
         part_num = _resolve_part_num(self._part_num)
         if not part_num:
             raise SystemExit(
@@ -114,14 +183,16 @@ class VivadoIp(VivadoSource):
         ]
 
         if self.builder_tcl is not None:
-            needs_build = any(
+            needs_build = force or any(
                 not p.exists() or outdated(p, [self.builder_tcl])
                 for p in resolved_paths
             )
             if needs_build:
                 execute_tcl([self.builder_tcl], cwd=build_dir)
 
-        outdated_paths = self._outofdate(build_dir, resolved_paths)
+        outdated_paths = (
+            resolved_paths if force else self._outofdate(build_dir, resolved_paths)
+        )
         if outdated_paths:
             tcl_path = self._write_generation_tcl(outdated_paths, build_dir, part_num)
             execute_tcl([tcl_path], cwd=build_dir)
@@ -233,14 +304,41 @@ class VivadoProject(VivadoSource):
         )
         self._part_num = part_num
 
-    def prepare(self, build_dir: Path, hdl_library: str) -> SimDirInfo:
+    def fingerprint(self) -> dict:
+        # builder_tcl, when set, is the canonical input; the .xpr it
+        # produces is derived. Without builder_tcl, the .xpr is the
+        # canonical input and must be hashed.
+        if self.builder_tcl is not None:
+            xpr_field: object = str(self.xpr_path)
+            builder = {
+                "path": str(self.builder_tcl),
+                "sha256": _hash_file(self.builder_tcl),
+            }
+        else:
+            xpr_field = {
+                "path": str(self.xpr_path),
+                "sha256": _hash_file(self.xpr_path),
+            }
+            builder = None
+        return {
+            "kind": "VivadoProject",
+            "xpr": xpr_field,
+            "builder_tcl": builder,
+            "part_num": self._part_num or "",
+        }
+
+    def prepare(
+        self, build_dir: Path, hdl_library: str, force: bool = False
+    ) -> SimDirInfo:
         xpr_path = (
             self.xpr_path
             if self.xpr_path.is_absolute()
             else (build_dir / self.xpr_path).resolve()
         )
 
-        if self.builder_tcl is not None and outdated(xpr_path, [self.builder_tcl]):
+        if self.builder_tcl is not None and (
+            force or outdated(xpr_path, [self.builder_tcl])
+        ):
             execute_tcl([self.builder_tcl], cwd=build_dir)
 
         export_dir = xpr_path.parent / f"{xpr_path.stem}.sim" / "sim_1" / "behav"
@@ -250,7 +348,7 @@ class VivadoProject(VivadoSource):
         if self.builder_tcl is not None:
             rebuild_inputs.append(self.builder_tcl)
 
-        if outdated(result_file, rebuild_inputs):
+        if force or outdated(result_file, rebuild_inputs):
             tcl_path = build_dir / "launch_xpr.tcl"
             lines = [f"open_project {xpr_path}"]
             if self._part_num:
@@ -301,7 +399,33 @@ class VivadoExportedSim(VivadoSource):
         )
         self.force_extract: bool = force_extract
 
-    def prepare(self, build_dir: Path, hdl_library: str) -> SimDirInfo:
+    def fingerprint(self) -> dict:
+        # tcl_file, when set, is the canonical input. Without it the
+        # source is content-defined by whatever's already in result_dir,
+        # so hash that directory's manifest instead.
+        if self.tcl_file is not None:
+            tcl_field: object = {
+                "path": str(self.tcl_file),
+                "sha256": _hash_file(self.tcl_file),
+            }
+            result_field: object = str(self.result_dir)
+        else:
+            tcl_field = None
+            result_field = {
+                "path": str(self.result_dir),
+                "sha256": _hash_dir(self.result_dir),
+            }
+        return {
+            "kind": "VivadoExportedSim",
+            "tcl_file": tcl_field,
+            "result_dir": result_field,
+            "result_file": str(self.result_file) if self.result_file else None,
+            "force_extract": self.force_extract,
+        }
+
+    def prepare(
+        self, build_dir: Path, hdl_library: str, force: bool = False
+    ) -> SimDirInfo:
         export_dir = (
             self.result_dir
             if self.result_dir.is_absolute()
@@ -317,7 +441,9 @@ class VivadoExportedSim(VivadoSource):
             )
         )
 
-        if self.tcl_file is not None and outdated(result_file, [self.tcl_file]):
+        if self.tcl_file is not None and (
+            force or outdated(result_file, [self.tcl_file])
+        ):
             tcl_paths: list = [self.tcl_file]
             if self.force_extract:
                 forced = build_dir / "extract_scripts.tcl"
@@ -421,7 +547,35 @@ class VivadoBd(VivadoSource):
         """
         return "xil_defaultlib"
 
-    def prepare(self, build_dir: Path, hdl_library: str) -> SimDirInfo:
+    def fingerprint(self) -> dict:
+        # builder_tcl, when set, is the canonical input; the .bd it
+        # produces is derived. Without builder_tcl, the .bd is the
+        # canonical input and must be hashed. wrapper / top change the
+        # generated toplevel, so they belong in the identity.
+        if self.builder_tcl is not None:
+            bd_field: object = str(self.bd_path)
+            builder = {
+                "path": str(self.builder_tcl),
+                "sha256": _hash_file(self.builder_tcl),
+            }
+        else:
+            bd_field = {
+                "path": str(self.bd_path),
+                "sha256": _hash_file(self.bd_path),
+            }
+            builder = None
+        return {
+            "kind": "VivadoBd",
+            "bd": bd_field,
+            "builder_tcl": builder,
+            "part_num": _resolve_part_num(self._part_num) or "",
+            "wrapper": self.wrapper,
+            "top": self._top_override,
+        }
+
+    def prepare(
+        self, build_dir: Path, hdl_library: str, force: bool = False
+    ) -> SimDirInfo:
         part_num = _resolve_part_num(self._part_num)
         if not part_num:
             raise SystemExit(
@@ -436,7 +590,9 @@ class VivadoBd(VivadoSource):
             else (build_dir / self.bd_path).resolve()
         )
 
-        if self.builder_tcl is not None and outdated(bd_path, [self.builder_tcl]):
+        if self.builder_tcl is not None and (
+            force or outdated(bd_path, [self.builder_tcl])
+        ):
             execute_tcl([self.builder_tcl], cwd=build_dir)
 
         proj_name = self.bd_path.stem
@@ -448,7 +604,7 @@ class VivadoBd(VivadoSource):
         if self.builder_tcl is not None:
             rebuild_inputs.append(self.builder_tcl)
 
-        if outdated(result_file, rebuild_inputs):
+        if force or outdated(result_file, rebuild_inputs):
             tcl_path = self._write_generation_tcl(
                 bd_path, proj_dir, proj_name, part_num, build_dir
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
 """Shared pytest fixtures and test-session setup.
 
-TEMPORARY — remove the ``cocotb_vivado`` import below together with the
-legacy ``cocotb_vivado.run()`` path.
+Per-test ``build_dir`` keeps each test's compile/elab artifacts and
+build signature isolated under ``tests/sim_build/<test_module>/``, so
+the Tier 1 build cache holds across full-suite reruns. Without
+isolation, the suite would share one ``sim_build/`` and each test
+overwrites the previous test's signature, defeating the cache for any
+subsequent suite run.
+
+The ``cocotb_vivado`` import below is TEMPORARY — remove it together
+with the legacy ``cocotb_vivado.run()`` path.
 
 Importing ``cocotb_vivado`` replaces ``cocotb.simulator`` with the
 in-process XSI stub, and cocotb caches the simulator handle at its own
@@ -11,13 +18,16 @@ so the stub has to be installed before anything imports cocotb.
 pytest imports this file before any test module, which makes it the only
 place the ordering can be guaranteed for a whole-suite run: fixing the
 import order inside a single test module is not enough, because an
-earlier-collected module (``test_axil.py``) imports cocotb first.
+earlier-collected module (``test_axil.py``) imports cocotb first. Neither
+``pathlib`` nor ``pytest`` pulls in cocotb, so the import keeps its
+normal isort position here.
 
 Runner-based tests are unaffected either way — they simulate in a
 ``python -m cocotb_vivado`` subprocess that controls its own import order.
 """
 
 import ctypes
+from pathlib import Path
 
 import pytest
 
@@ -65,3 +75,10 @@ def pytest_collection_modifyitems(
     for item in items:
         if "in_process_xsi" in item.keywords:
             item.add_marker(skip)
+
+
+@pytest.fixture
+def build_dir(request: pytest.FixtureRequest) -> Path:
+    """``tests/sim_build/<test_module>/`` — co-located with the test file."""
+    test_file = Path(request.path)
+    return test_file.parent / "sim_build" / test_file.stem

--- a/tests/test_axil.py
+++ b/tests/test_axil.py
@@ -35,22 +35,25 @@ async def cocotb_axil_test(dut):
     assert data_in == data_out
 
 
-def test_axil():
+def test_axil(build_dir):
     proj_path = Path(__file__).resolve().parent
     runner = get_runner(os.getenv("SIM", "vivado"))
     runner.build(
         sources=[proj_path / "test_axil.v"],
         hdl_toplevel="test_axil",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="test_axil",
         test_module="test_axil",
         hdl_toplevel_lang="verilog",
         testcase="cocotb_axil_test",
+        build_dir=str(build_dir),
     )
 
 
 if __name__ == "__main__":
-    test_axil()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_axil(_build_dir)

--- a/tests/test_bd_axi.py
+++ b/tests/test_bd_axi.py
@@ -91,7 +91,7 @@ async def bd_axi_test(dut):
     dut.areset.value = 0
 
 
-def test_bd_axi():
+def test_bd_axi(build_dir):
     proj_path = Path(__file__).resolve().parent
     runner = get_runner(os.getenv("SIM", "vivado"))
     bd = VivadoBd(
@@ -104,6 +104,7 @@ def test_bd_axi():
         hdl_toplevel=bd.top,
         hdl_library=bd.library,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel=bd.top,
@@ -111,8 +112,10 @@ def test_bd_axi():
         test_module="test_bd_axi",
         hdl_toplevel_lang="verilog",
         testcase="bd_axi_test",
+        build_dir=str(build_dir),
     )
 
 
 if __name__ == "__main__":
-    test_bd_axi()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_bd_axi(_build_dir)

--- a/tests/test_bd_simple.py
+++ b/tests/test_bd_simple.py
@@ -38,7 +38,7 @@ async def inverter_smoke(dut):
         )
 
 
-def test_bd_simple():
+def test_bd_simple(build_dir):
     proj_path = Path(__file__).resolve().parent
     runner = get_runner(os.getenv("SIM", "vivado"))
     bd = VivadoBd(
@@ -52,14 +52,17 @@ def test_bd_simple():
         hdl_toplevel=bd.top,
         hdl_library=bd.library,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel=bd.top,
         hdl_toplevel_library=bd.library,
         test_module="test_bd_simple",
         hdl_toplevel_lang="verilog",
+        build_dir=str(build_dir),
     )
 
 
 if __name__ == "__main__":
-    test_bd_simple()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_bd_simple(_build_dir)

--- a/tests/test_bram.py
+++ b/tests/test_bram.py
@@ -34,7 +34,7 @@ async def clocks_only(dut):
     await Timer(200, units="ns")
 
 
-def test_bram():
+def test_bram(build_dir):
     proj_path = Path(__file__).resolve().parent
     runner = get_runner(os.getenv("SIM", "vivado"))
     runner.build(
@@ -48,13 +48,16 @@ def test_bram():
         ],
         hdl_toplevel="bram_wrap",
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="bram_wrap",
         test_module="test_bram",
         hdl_toplevel_lang="verilog",
+        build_dir=str(build_dir),
     )
 
 
 if __name__ == "__main__":
-    test_bram()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_bram(_build_dir)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,325 @@
+"""Tier 1 build-cache mechanics tests.
+
+Most scenarios are unit-style — exercise hashing, signature
+serialization, and per-VivadoSource fingerprint() output directly,
+without invoking ``runner.build()``. One end-to-end integration test
+proves the cache hit/miss path through the runner; it's gated on
+Vivado availability and only runs locally.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from cocotb_vivado.runner import (
+    SIGNATURE_FILENAME,
+    SIGNATURE_SCHEMA_VERSION,
+    _hash_file,
+    _load_signature,
+    _save_signature,
+    get_runner,
+    get_xsim_tool_versions,
+)
+from cocotb_vivado.vivado import VivadoExportedSim, VivadoIp, VivadoProject
+from cocotb_vivado.vivado.sources import _hash_dir
+
+# ---------------------------------------------------------------------------
+# Primitives: _hash_file, _hash_dir, get_xsim_tool_versions
+# ---------------------------------------------------------------------------
+
+
+def test_hash_file_missing_returns_empty(tmp_path: Path) -> None:
+    assert _hash_file(tmp_path / "nope") == ""
+
+
+def test_hash_file_content_changes_invalidate(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello")
+    a = _hash_file(f)
+    f.write_text("hello!")
+    b = _hash_file(f)
+    assert a != b and len(a) == 64 and len(b) == 64
+
+
+def test_hash_file_touch_only_keeps_hash(tmp_path: Path) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hello")
+    a = _hash_file(f)
+    os.utime(f, (1_000_000, 1_000_000))
+    assert _hash_file(f) == a  # mtime change, content same
+
+
+def test_hash_dir_manifest_changes_on_content(tmp_path: Path) -> None:
+    d = tmp_path / "tree"
+    d.mkdir()
+    (d / "a.txt").write_text("aa")
+    (d / "b.txt").write_text("bb")
+    a = _hash_dir(d)
+    (d / "b.txt").write_text("bbX")
+    assert _hash_dir(d) != a
+
+
+def test_hash_dir_missing_returns_empty(tmp_path: Path) -> None:
+    assert _hash_dir(tmp_path / "absent") == ""
+
+
+# ---------------------------------------------------------------------------
+# Signature file roundtrip and error tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_signature_roundtrip(tmp_path: Path) -> None:
+    sig = {"schema_version": 1, "kwargs": {"a": 1}}
+    p = tmp_path / SIGNATURE_FILENAME
+    _save_signature(p, sig)
+    assert _load_signature(p) == sig
+
+
+def test_signature_corrupt_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / SIGNATURE_FILENAME
+    p.write_text("{not json")
+    assert _load_signature(p) is None
+
+
+def test_signature_absent_returns_none(tmp_path: Path) -> None:
+    assert _load_signature(tmp_path / SIGNATURE_FILENAME) is None
+
+
+# ---------------------------------------------------------------------------
+# VivadoSource.fingerprint() — pure dict-shape tests, no Vivado required
+# ---------------------------------------------------------------------------
+
+
+def test_vivado_ip_fingerprint_with_builder_tcl(tmp_path: Path) -> None:
+    tcl = tmp_path / "regen.tcl"
+    tcl.write_text("create_ip ...\n")
+    src = VivadoIp(
+        "ip/x.xci",
+        builder_tcl=tcl,
+        part_num="xczu7eg-ffvc1156-2-e",
+    )
+    fp = src.fingerprint()
+    assert fp["kind"] == "VivadoIp"
+    # builder_tcl set → paths recorded as identifiers (strings), not hashed
+    assert fp["paths"] == ["ip/x.xci"]
+    assert fp["builder_tcl"]["sha256"] == _hash_file(tcl)
+    assert fp["part_num"] == "xczu7eg-ffvc1156-2-e"
+
+
+def test_vivado_ip_fingerprint_without_builder_tcl(tmp_path: Path) -> None:
+    xci = tmp_path / "y.xci"
+    xci.write_text("<xci>...</xci>")
+    src = VivadoIp(xci, part_num="xczu7eg-ffvc1156-2-e")
+    fp = src.fingerprint()
+    assert fp["builder_tcl"] is None
+    # No builder_tcl → XCI itself must be hashed
+    assert fp["paths"][0]["sha256"] == _hash_file(xci)
+
+
+def test_vivado_ip_fingerprint_changes_on_part_num() -> None:
+    a = VivadoIp("ip/x.xci", part_num="xczu7eg-ffvc1156-2-e").fingerprint()
+    b = VivadoIp("ip/x.xci", part_num="xczu9eg-ffvb1156-2-e").fingerprint()
+    assert a != b
+
+
+def test_vivado_project_fingerprint_with_builder_tcl(tmp_path: Path) -> None:
+    tcl = tmp_path / "build.tcl"
+    tcl.write_text("create_project ...")
+    src = VivadoProject(xpr_path="proj/proj.xpr", builder_tcl=tcl)
+    fp = src.fingerprint()
+    assert fp["kind"] == "VivadoProject"
+    assert fp["xpr"] == "proj/proj.xpr"  # string identifier
+    assert fp["builder_tcl"]["sha256"] == _hash_file(tcl)
+
+
+def test_vivado_project_fingerprint_changes_on_part_num_override(
+    tmp_path: Path,
+) -> None:
+    """Distinct part_num must invalidate VivadoProject's signature."""
+    tcl = tmp_path / "b.tcl"
+    tcl.write_text("x")
+    a = VivadoProject(
+        xpr_path="p.xpr", builder_tcl=tcl, part_num="xczu7eg-ffvc1156-2-e"
+    ).fingerprint()
+    b = VivadoProject(
+        xpr_path="p.xpr", builder_tcl=tcl, part_num="xczu9eg-ffvb1156-2-e"
+    ).fingerprint()
+    assert a != b
+
+
+def test_vivado_exported_sim_fingerprint_with_tcl(tmp_path: Path) -> None:
+    tcl = tmp_path / "e.tcl"
+    tcl.write_text("launch_simulation ...")
+    src = VivadoExportedSim(tcl_file=tcl)
+    fp = src.fingerprint()
+    assert fp["kind"] == "VivadoExportedSim"
+    assert fp["tcl_file"]["sha256"] == _hash_file(tcl)
+
+
+def test_vivado_exported_sim_fingerprint_without_tcl(tmp_path: Path) -> None:
+    """tcl_file=None → identity is the result_dir's content manifest."""
+    rdir = tmp_path / "sim"
+    (rdir / "xsim").mkdir(parents=True)
+    (rdir / "xsim" / "elaborate.sh").write_text("xelab ...")
+    src = VivadoExportedSim(tcl_file=None, result_dir=rdir)
+    fp = src.fingerprint()
+    assert fp["tcl_file"] is None
+    assert fp["result_dir"]["sha256"] == _hash_dir(rdir)
+
+
+# ---------------------------------------------------------------------------
+# get_xsim_tool_versions — smoke-test that it returns the expected key shape
+# ---------------------------------------------------------------------------
+
+
+def test_get_xsim_tool_versions_shape() -> None:
+    versions = get_xsim_tool_versions()
+    assert set(versions.keys()) == {"xelab", "xvlog", "xvhdl"}
+    # values are strings (possibly empty if tools aren't on PATH)
+    assert all(isinstance(v, str) for v in versions.values())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end cache integration: build twice, assert hit on second run
+# ---------------------------------------------------------------------------
+
+
+def _vivado_on_path() -> bool:
+    return all(shutil.which(t) for t in ("xelab", "xvlog", "xvhdl"))
+
+
+@pytest.mark.skipif(not _vivado_on_path(), reason="vivado XSim binaries not on PATH")
+def test_cache_hit_skips_pipeline_on_second_build(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    proj_path = Path(__file__).resolve().parent
+    runner = get_runner("vivado")
+
+    common_kwargs = {
+        "sources": [proj_path / "tb.v"],
+        "hdl_toplevel": "tb",
+        "always": False,
+        "timescale": ("1ns", "1ps"),
+        "build_dir": str(tmp_path),
+    }
+
+    # Cold cache: signature is absent → expect a miss + xvlog/xelab run.
+    with caplog.at_level(logging.INFO, logger="cocotb_vivado.runner.cache"):
+        runner.build(**common_kwargs)
+        assert any("cache miss" in r.message for r in caplog.records), (
+            "first build should miss the cache"
+        )
+
+    # Signature file should now exist and have the expected schema.
+    sig_path = tmp_path / SIGNATURE_FILENAME
+    assert sig_path.exists()
+    sig = _load_signature(sig_path)
+    assert sig is not None
+    assert sig["schema_version"] == SIGNATURE_SCHEMA_VERSION
+
+    # Warm cache: same inputs → expect a hit.
+    caplog.clear()
+    snapshot_mtime_before = (tmp_path / "xsim.dir" / "tb" / "xsimk.so").stat().st_mtime
+    with caplog.at_level(logging.INFO, logger="cocotb_vivado.runner.cache"):
+        runner.build(**common_kwargs)
+        assert any("cache hit" in r.message for r in caplog.records), (
+            "second build with identical inputs should hit the cache"
+        )
+
+    # Cache hit must not touch the snapshot artifact.
+    snapshot_mtime_after = (tmp_path / "xsim.dir" / "tb" / "xsimk.so").stat().st_mtime
+    assert snapshot_mtime_before == snapshot_mtime_after
+
+
+@pytest.mark.skipif(not _vivado_on_path(), reason="vivado XSim binaries not on PATH")
+def test_cache_miss_on_parameters_change(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    proj_path = Path(__file__).resolve().parent
+    runner = get_runner("vivado")
+
+    # Initial build with one parameter set; uses tb_params.v whose
+    # WIDTH parameter is honored by -generic_top.
+    runner.build(
+        sources=[proj_path / "tb_params.v"],
+        hdl_toplevel="tb_params",
+        parameters={"WIDTH": 8},
+        always=False,
+        timescale=("1ns", "1ps"),
+        build_dir=str(tmp_path),
+    )
+    sig_a = _load_signature(tmp_path / SIGNATURE_FILENAME)
+
+    # Change a parameter; rebuild.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cocotb_vivado.runner.cache"):
+        runner.build(
+            sources=[proj_path / "tb_params.v"],
+            hdl_toplevel="tb_params",
+            parameters={"WIDTH": 16},
+            always=False,
+            timescale=("1ns", "1ps"),
+            build_dir=str(tmp_path),
+        )
+    sig_b = _load_signature(tmp_path / SIGNATURE_FILENAME)
+
+    assert sig_a != sig_b, "parameter change should rewrite the signature"
+    assert any("cache miss: signature mismatch" in r.message for r in caplog.records), (
+        "parameter change should report mismatch"
+    )
+
+
+@pytest.mark.skipif(not _vivado_on_path(), reason="vivado XSim binaries not on PATH")
+def test_cache_miss_when_snapshot_deleted(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    proj_path = Path(__file__).resolve().parent
+    runner = get_runner("vivado")
+    common_kwargs = {
+        "sources": [proj_path / "tb.v"],
+        "hdl_toplevel": "tb",
+        "always": False,
+        "timescale": ("1ns", "1ps"),
+        "build_dir": str(tmp_path),
+    }
+    runner.build(**common_kwargs)
+
+    # Delete the snapshot but leave build_signature.json in place.
+    shutil.rmtree(tmp_path / "xsim.dir")
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cocotb_vivado.runner.cache"):
+        runner.build(**common_kwargs)
+        assert any("snapshot artifact missing" in r.message for r in caplog.records), (
+            "deleted snapshot must trigger a cache miss"
+        )
+
+
+@pytest.mark.skipif(not _vivado_on_path(), reason="vivado XSim binaries not on PATH")
+def test_cache_corrupt_signature_treated_as_miss(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    proj_path = Path(__file__).resolve().parent
+    runner = get_runner("vivado")
+    common_kwargs = {
+        "sources": [proj_path / "tb.v"],
+        "hdl_toplevel": "tb",
+        "always": False,
+        "timescale": ("1ns", "1ps"),
+        "build_dir": str(tmp_path),
+    }
+    # Pre-create a corrupt signature; should be silently treated as miss.
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / SIGNATURE_FILENAME).write_text("{not json")
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cocotb_vivado.runner.cache"):
+        runner.build(**common_kwargs)
+        assert any(
+            "signature absent or unreadable" in r.message for r in caplog.records
+        )

--- a/tests/test_fw.py
+++ b/tests/test_fw.py
@@ -85,7 +85,7 @@ async def cocotb_fw_test(dut):
     dut.areset.value = 0
 
 
-def test_fw():
+def test_fw(build_dir):
     proj_path = Path(__file__).resolve().parent
     runner = get_runner(os.getenv("SIM", "vivado"))
     runner.build(
@@ -97,8 +97,9 @@ def test_fw():
         ],
         hdl_toplevel="fw_wrapper",
         hdl_library="xil_defaultlib",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="fw_wrapper",
@@ -106,8 +107,10 @@ def test_fw():
         test_module="test_fw",
         hdl_toplevel_lang="verilog",
         testcase="cocotb_fw_test",
+        build_dir=str(build_dir),
     )
 
 
 if __name__ == "__main__":
-    test_fw()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_fw(_build_dir)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -30,7 +30,7 @@ async def cocotb_param_test(dut):
     )
 
 
-def _run(parameters):
+def _run(build_dir, parameters):
     proj_path = Path(__file__).resolve().parent
     sources = [proj_path / "tb_params.v"]
 
@@ -40,38 +40,41 @@ def _run(parameters):
     runner.build(
         sources=sources,
         hdl_toplevel="tb_params",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
         parameters=parameters,
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="tb_params",
         test_module="test_params",
         hdl_toplevel_lang="verilog",
         testcase="cocotb_param_test",
+        build_dir=str(build_dir),
     )
 
 
-def test_params_default():
+def test_params_default(build_dir):
     os.environ["EXPECTED_WIDTH"] = "8"
     os.environ["EXPECTED_DEPTH"] = "4"
-    _run(parameters={})
+    _run(build_dir, parameters={})
 
 
-def test_params_override():
+def test_params_override(build_dir):
     os.environ["EXPECTED_WIDTH"] = "16"
     os.environ["EXPECTED_DEPTH"] = "7"
-    _run(parameters={"WIDTH": 16, "DEPTH": 7})
+    _run(build_dir, parameters={"WIDTH": 16, "DEPTH": 7})
 
 
-def test_params_unknown():
+def test_params_unknown(build_dir):
     os.environ["EXPECTED_WIDTH"] = "8"
     os.environ["EXPECTED_DEPTH"] = "4"
     with pytest.raises(SystemExit):
-        _run(parameters={"NOT_A_REAL_PARAM": 1234})
+        _run(build_dir, parameters={"NOT_A_REAL_PARAM": 1234})
 
 
 if __name__ == "__main__":
-    test_params_default()
-    test_params_override()
-    test_params_unknown()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_params_default(_build_dir)
+    test_params_override(_build_dir)
+    test_params_unknown(_build_dir)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -20,7 +20,7 @@ async def simple_test(dut):
     assert dut.out.value == 1
 
 
-def test_simple():
+def test_simple(build_dir):
     """Build tb.v with the Python runner and run the cocotb test."""
     proj_path = Path(__file__).resolve().parent
     sources = [proj_path / "tb.v"]
@@ -31,14 +31,16 @@ def test_simple():
     runner.build(
         sources=sources,
         hdl_toplevel="tb",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="tb",
         test_module="test_simple",
         hdl_toplevel_lang="verilog",
         testcase="simple_test",
+        build_dir=str(build_dir),
     )
 
 
@@ -63,4 +65,5 @@ def test_simple_directlaunch():
 
 
 if __name__ == "__main__":
-    test_simple()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_simple(_build_dir)

--- a/tests/test_tb.py
+++ b/tests/test_tb.py
@@ -51,7 +51,7 @@ async def cocotb_tb_test_fail(dut):
     pytest.fail("deliberate failure to exercise the xfail path")
 
 
-def _run_tb(test_module="test_tb", testcase="cocotb_tb_test"):
+def _run_tb(build_dir, test_module="test_tb", testcase="cocotb_tb_test"):
     proj_path = Path(__file__).resolve().parent
     sources = [proj_path / "tb.v"]
 
@@ -61,30 +61,33 @@ def _run_tb(test_module="test_tb", testcase="cocotb_tb_test"):
     runner.build(
         sources=sources,
         hdl_toplevel="tb",
-        always=True,
+        always=False,
         timescale=("1ns", "1ps"),
+        build_dir=str(build_dir),
     )
     runner.test(
         hdl_toplevel="tb",
         test_module=test_module,
         hdl_toplevel_lang="verilog",
         testcase=testcase,
+        build_dir=str(build_dir),
     )
 
 
-def test_tb():
-    _run_tb(testcase="cocotb_tb_test")
+def test_tb(build_dir):
+    _run_tb(build_dir, testcase="cocotb_tb_test")
 
 
 @pytest.mark.xfail
-def test_tb_fail():
-    _run_tb(testcase="cocotb_tb_test_fail")
+def test_tb_fail(build_dir):
+    _run_tb(build_dir, testcase="cocotb_tb_test_fail")
 
 
 @pytest.mark.xfail
-def test_tb_fail_init():
-    _run_tb(test_module="no_existing")
+def test_tb_fail_init(build_dir):
+    _run_tb(build_dir, test_module="no_existing")
 
 
 if __name__ == "__main__":
-    test_tb()
+    _build_dir = Path(__file__).resolve().parent / "sim_build" / Path(__file__).stem
+    test_tb(_build_dir)


### PR DESCRIPTION
Follow-up to #14. Skips the whole compile/elaborate pipeline when nothing that affects output changed — directly addressing the "can we skip compilation if the design is already compiled" question raised on #14.

## What
- A content-hash signature at `build_dir/build_signature.json` covering: user HDL content, every output-affecting kwarg (parameters, defines, build_args, includes, timescale, waves, wave_format, hdl_toplevel/library, …), each `VivadoSource.fingerprint()`, and `xelab`/`xvlog`/`xvhdl --version`. On a hit the entire pipeline — including `VivadoSource.prepare()` — is skipped. `always=True` bypasses the cache.
- `VivadoSource.fingerprint()` + a `force=` rerun kwarg: a cache miss calls `prepare(force=True)` so a source re-runs even when input *content* changed without its mtime changing (e.g. after `git checkout`).
- Cache-invalidation tests; tests/examples switch to `always=False` + per-test `build_dir`.

## Testing
CI here is lint/type only (no Vivado). Simulation suite run locally on cocotb 1.9.2, Vivado **2023.1** (all pass) and **2025.1** (all pass except the pre-existing `test_fw` fixture limitation, unrelated to this change).

Independent of #(value-change-manager) — disjoint files, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)